### PR TITLE
Fixing a small typo

### DIFF
--- a/ch-first-order-ode.tex
+++ b/ch-first-order-ode.tex
@@ -5,8 +5,7 @@
 \section{Integrals as solutions}
 \label{integralsols:section}
 
-\sectionnotes{1 lecture (or less)\EPref{, \S1.2 in \cite{EP}}\BDref{,
-covered in \S1.2 and \S2.1 in \cite{BD}}}
+
 
 A first order ODE is an equation of the form
 \begin{equation*}
@@ -273,131 +272,193 @@ question.
 \subsection{Exercises}
 
 \begin{exercise}
-Solve $\frac{dy}{dx} = x^2+x$ for $y(1)=3$.
-\end{exercise}
-
-\begin{exercise}
-Solve $\frac{dy}{dx} = \sin (5x)$ for $y(0)=2$.
-\end{exercise}
-
-\begin{exercise}
-Solve $\frac{dy}{dx} = \frac{1}{x^2-1}$ for $y(0)=0$.
-\end{exercise}
-
-\begin{exercise}
-Solve $y' = y^3$ for $y(0)=1$.
-\end{exercise}
-
-\begin{exercise}[little harder]
-Solve $y' = (y-1)(y+1)$ for $y(0)=3$.
-\end{exercise}
-
-\begin{exercise}
-Solve $\frac{dy}{dx} = \frac{1}{y+1}$ for $y(0)=0$.
-\end{exercise}
-
-\begin{exercise}[harder]
-Solve $y'' = \sin x$ for $y(0)=0$, $y'(0) = 2$.
-\end{exercise}
-
-\begin{exercise}
-A spaceship is traveling at the speed \unitfrac[$2t^2+1$]{km}{s} ($t$ is
-time in seconds).  It is pointing directly away from earth and at time $t=0$
-it is 1000 kilometers from earth.  How far from earth is it at one minute from
-time $t=0$?
-\end{exercise}
-
-\begin{exercise}
-Solve $\frac{dx}{dt} = \sin(t^2)+t$, $x(0)=20$.  It is OK to leave your
-answer as a definite integral.
-\end{exercise}
-
-\begin{exercise}
-A dropped ball accelerates downwards at a constant rate $9.8$ meters per second
-squared.  Set up the differential equation for the height above ground $h$ in meters.
-Then supposing $h(0) = 100$ meters, how long does it take for the ball to hit
-the ground.
-\end{exercise}
-
-\begin{exercise}
-Find the general solution of
-$y' = e^x$,  and then $y' = e^y$.
-\end{exercise}
-
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Solve $\frac{dy}{dx} = e^x + x$ and $y(0) = 10$.
-\end{exercise}
-\exsol{%
-$y = e^x + \frac{x^2}{2} + 9$
-}
-
-\begin{exercise}
-Solve $x' = \frac{1}{x^2}$, $x(1)=1$.
-\end{exercise}
-\exsol{%
-$x = {(3t-2)}^{1/3}$
-}
-
-\begin{exercise}
-Solve $x' = \frac{1}{\cos(x)}$, $x(0)=\frac{\pi}{2}$.
-\end{exercise}
-\exsol{%
-$x = \sin^{-1} \bigl(t+1\bigr)$
-}
-
-\begin{exercise}
-Sid is in a car traveling at speed $10t+70$ miles per hour away from Las Vegas,
-where $t$ is in hours.  At $t=0$, Sid is 10 miles away from Vegas.  How
-far from Vegas is Sid 2 hours later?
-\end{exercise}
-\exsol{%
-170
-}
-
-\begin{exercise}
-Solve $y' = y^n$, $y(0) = 1$, where $n$ is a positive integer.
-Hint: You have to consider different cases.
-\end{exercise}
-\exsol{%
-If $n \not= 1$, then
-$y={\bigl((1-n)x+1\bigr)}^{1/(1-n)}$.
-If $n=1$, then $y = e^x$.
-}
-
-\begin{exercise}
-The rate of change of the volume of a snowball that is melting is 
-proportional to the surface area of the snowball.  Suppose the
-snowball is perfectly spherical.  The volume (in centimeters cubed)
-of a ball of radius $r$ centimeters is
-$(\nicefrac{4}{3}) \pi r^3$.  The surface area is
-$4 \pi r^2$.  Set up the differential equation for how the radius $r$ is changing.
-Then, suppose that at time $t=0$ minutes, the radius is 10 centimeters.
-After 5 minutes, the radius is 8 centimeters.  At what time $t$ will the 
-snowball be completely melted?
-\end{exercise}
-\exsol{%
-The equation is $r' = -C$ for some constant $C$.
-The snowball will be completely melted in 25 minutes from time $t=0$.
-}
-
-\begin{exercise}
-Find the general solution to $y''''= 0$.  How many distinct constants do you need?
-\end{exercise}
-\exsol{%
-$y = Ax^3 + Bx^2 + Cx + D$, so 4 constants.
-}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    Solve $\frac{dy}{dx} = x^2+x$ for $y(1)=3$.
+    \end{exercise}
+    \exsolution{%
+    Integrating with respect to $x$ we get $y=\frac{x^3}{3}+\frac{x^2}{2}+c$. 
+    $y(1)=\frac{1}{3}+\frac{1}{2}+c=3\rightarrow c=\frac{13}{6}$.
+    \[
+    y=\frac{x^3}{3}+\frac{x^2}{2}+\frac{13}{6}
+    \]
+    }
+    
+    
+    
+    \begin{exercise}
+    Solve $\frac{dy}{dx} = \sin (5x)$ for $y(0)=2$.
+    \end{exercise}
+    \exsol{% 
+    $y=-\frac{\cos 5x}{5}+\frac{11}{5}$
+    }
+    
+    \begin{exercise}
+    Solve $\frac{dy}{dx} = \frac{1}{x^2-1}$ for $y(0)=0$.
+    \end{exercise}
+    \exsol{%
+    $y=\frac{1}{2}\ln\left(\frac{1-x}{1+x}\right)$
+    }
+    
+    \begin{exercise}
+    Solve $y' = y^3$ for $y(0)=1$.
+    \end{exercise}
+    \exsolution{%
+    Writing as $\frac{dy}{dx}=y^3\rightarrow \frac{dx}{dy}=\frac{1}{y^3}\rightarrow \frac{dx}{dy}dy=\frac{1}{y^3}dy$ and integrating we get 
+    \[
+    x+c=\frac{y^{-2}}{-2	}
+    \]
+    \[
+    y=\sqrt{\frac{1}{-2x-c}},\quad y(0)=\sqrt{\frac{1}{-c}}=1\rightarrow c=-1
+    \]
+    \[
+    \Rightarrow y=\sqrt{\frac{1}{1-2x}}
+    \]
+    }
+    
+    \begin{exercise}
+    Solve $y' = (y-1)(y+1)$ for $y(0)=3$.
+    \end{exercise}
+    \exsolution{%
+    \[
+    \int \frac{1}{(y+1)(y-1)}dy=\frac{1}{2}\int \frac{1}{y-1}-\frac{1}{y+1}dy=\frac{1}{2}\ln\left(\frac{y-1}{y+1}\right)=x+c
+    \]
+    \[
+    y(x)=\frac{ce^{2x}+1}{1-ce^{2x}},\quad y(0)=\frac{c+1}{1-c}=3\rightarrow\quad c=\frac{1}{2}
+    \]
+    \[
+    \Rightarrow y=\frac{e^{2x}+2}{2-e^{2x}}
+    \]
+    }
+    
+    \begin{exercise}
+    Solve $\frac{dy}{dx} = \frac{1}{y+1}$ for $y(0)=0$.
+    \end{exercise}
+    \exsol{%
+    $y=\sqrt{2x+1}-1$
+    }
+    
+    \begin{exercise}
+    Solve $y'' = \sin x$ for $y(0)=0$, $y'(0) = 2$.
+    \end{exercise}
+    \exsol{%
+    $y=-\sin x+3x$
+    }
+    
+    \begin{exercise}
+    A spaceship is traveling at the speed \unitfrac[$2t^2+1$]{km}{s} ($t$ is
+    time in seconds).  It is pointing directly away from earth and at time $t=0$
+    it is 1000 kilometers from earth.  How far from earth is it at one minute from
+    time $t=0$?
+    \end{exercise}
+    \exsol{%
+    $x(60)=145,060$ km
+    }
+    
+    \begin{exercise}
+    Solve $\frac{dx}{dt} = \sin(t^2)+t$, $x(0)=20$.  It is OK to leave your
+    answer as a definite integral.
+    \end{exercise}
+    \exsol{%
+    $x(t)=\int_0^t \sin(s^2)+s\ ds+20$
+    }
+    
+    \begin{exercise}
+    A dropped ball accelerates downwards at a constant rate $9.8$ meters per second
+    squared.  Set up the differential equation for the height above ground $h$ in meters.
+    Then supposing $h(0) = 100$ meters, how long does it take for the ball to hit
+    the ground.
+    \end{exercise}
+    \exsolution{%
+    $v'=-9.8,\rightarrow\quad v=-9.8t+v_0=h'$ the ball is '\emph{dropped}', so $v_0=0$.
+    \[
+    h=-\frac{9.8}{2}t^2+h_0,\quad h(0)=h_0=100
+    \]
+    \[
+    h=-\frac{9.8}{2}t^2+100\rightarrow\quad h(t_g)=0\rightarrow\quad t_g^2=\frac{200}{9.8}\rightarrow\quad t_g=4.52\ \rm s
+    \]
+    }
+    
+    \begin{exercise}
+    Find the general solution of
+    $y' = e^x$,  and then $y' = e^y$.
+    \end{exercise}
+    \exsol{%
+    $y=-\ln(-x-c)$
+    }
+    
+    
+    \setcounter{exercise}{100}
+    
+    \begin{exercise}
+    Solve $\frac{dy}{dx} = e^x + x$ and $y(0) = 10$.
+    \end{exercise}
+    \exsol{%
+    $y = e^x + \frac{x^2}{2} + 9$
+    }
+    
+    \begin{exercise}
+    Solve $x' = \frac{1}{x^2}$, $x(1)=1$.
+    \end{exercise}
+    \exsol{%
+    $x = {(3t-2)}^{1/3}$
+    }
+    
+    \begin{exercise}
+    Solve $x' = \frac{1}{\cos(x)}$, $x(0)=\frac{\pi}{2}$.
+    \end{exercise}
+    \exsol{%
+    $x = \sin^{-1} \bigl(t+1\bigr)$
+    }
+    
+    \begin{exercise}
+    Sid is in a car traveling at speed $10t+70$ miles per hour away from Las Vegas,
+    where $t$ is in hours.  At $t=0$, Sid is 10 miles away from Vegas.  How
+    far from Vegas is Sid 2 hours later?
+    \end{exercise}
+    \exsol{%
+    170
+    }
+    
+    \begin{exercise}
+    Solve $y' = y^n$, $y(0) = 1$, where $n$ is a positive integer.
+    Hint: You have to consider different cases.
+    \end{exercise}
+    \exsol{%
+    If $n \not= 1$, then
+    $y={\bigl((1-n)x+1\bigr)}^{1/(1-n)}$.
+    If $n=1$, then $y = e^x$.
+    }
+    
+    \begin{exercise}
+    The rate of change of the volume of a snowball that is melting is 
+    proportional to the surface area of the snowball.  Suppose the
+    snowball is perfectly spherical.  The volume (in centimeters cubed)
+    of a ball of radius $r$ centimeters is
+    $(\nicefrac{4}{3}) \pi r^3$.  The surface area is
+    $4 \pi r^2$.  Set up the differential equation for how the radius $r$ is changing.
+    Then, suppose that at time $t=0$ minutes, the radius is 10 centimeters.
+    After 5 minutes, the radius is 8 centimeters.  At what time $t$ will the 
+    snowball be completely melted?
+    \end{exercise}
+    \exsol{%
+    The equation is $r' = -C$ for some constant $C$.
+    The snowball will be completely melted in 25 minutes from time $t=0$.
+    }
+    
+    \begin{exercise}
+    Find the general solution to $y''''= 0$.  How many distinct constants do you need?
+    \end{exercise}
+    \exsol{%
+    $y = Ax^3 + Bx^2 + Cx + D$, so 4 constants.
+    }
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \sectionnewpage
 \section{Slope fields}
 \label{slopefields:section}
 
-\sectionnotes{1 lecture\EPref{, \S1.3 in \cite{EP}}\BDref{,
-\S1.1 in \cite{BD}}}
+
+
 
 %At this point it may be good to first try the
 %Lab I\index{IODE software!Lab I} and/or Project I\index{IODE software!Project I} from the
@@ -413,7 +474,14 @@ A lot of the time, we cannot simply solve these kinds of equations explicitly.
 It would be nice if we could at least figure out the shape and behavior of
 the solutions, or find approximate solutions.
 
+
 \subsection{Slope fields}
+
+\begin{video}[-S5qwlphcRY][Slope Fields][first-slope]
+	We can visually describe 1st order ODEs using Slope Fields, which allows us to encode the slope at any point. We will see that the concepts of differential equations, solutions, an initial conditions that we have thus far described analytically - i.e. with equations - all have a geometric parallel.
+\end{video}
+
+
 
 %As you have seen in IODE Lab I (if you did it),
 The equation $y' = f(x,y)$
@@ -498,6 +566,10 @@ looking at the slope field itself.
 \end{myfig}
 
 \subsection{Existence and uniqueness}
+
+\begin{video}[Ggt6O2bff54][Existence and Uniqueness][first-existence]
+    The key theorems that makes differential equations work are called Existence and Uniqueness theorems. They tell you, depending on the type of ODE, when solutions exist, and when they are unique. This is pretty crucial, because otherwise we'd never know whether it was worth bothering to try to find a solution, or if we found one whether to keep looking. We will see many Existence and Uniqueness theorems, but for now we are focusing specifically on 1st order ODEs. 
+\end{video}
 
 We wish to ask two fundamental questions about the problem
 \begin{equation*}
@@ -595,9 +667,9 @@ possible that the solution only exists for a short while.
 
 \begin{example}
 For some constant $A$, solve:
-\begin{equation*}
+\[
 y' = y^2, \qquad y(0) = A .
-\end{equation*}
+\]
 
 We know how to solve this equation.  First assume that $A \not= 0$,
 so $y$ is not equal to zero at least for some $x$ near 0.  So
@@ -625,6 +697,8 @@ $y'=y^2$.
 
 \subsection{Exercises}
 
+For problems 1-5, try sketching by hand first, then you can use the Slope Field plotter to see the answer: \href{https://www.geogebra.org/m/z9c3ndaf}{https://www.geogebra.org/m/z9c3ndaf}.
+
 \begin{exercise}
 Sketch slope field for $y'=e^{x-y}$.  How do the solutions behave as $x$
 grows?  Can you guess a particular solution by looking at the slope
@@ -637,17 +711,6 @@ Sketch slope field for $y'=x^2$.
 
 \begin{exercise}
 Sketch slope field for $y'=y^2$.
-\end{exercise}
-
-\begin{exercise}
-Is it possible to solve the equation $y' = \frac{xy}{\cos x}$ for $y(0) = 1$?
-Justify.
-\end{exercise}
-
-\begin{exercise}
-Is it possible to solve the equation $y' = y\sqrt{\lvert x\rvert}$ for
-$y(0) = 0$?  Is the solution unique?
-Justify.
 \end{exercise}
 
 \begin{samepage}
@@ -663,7 +726,51 @@ Justify.
 \parbox[c]{1.75in}{\includegraphics[width=1.75in]{figures/yprimexminus2yslope}}
 \end{tasks}
 \end{exercise}
+\exsol{%
+a) $y' = x(1-y)$, \quad
+b) $y'=1-x$, \quad
+c) $y'=x-2y$. \quad
+}
 \end{samepage}
+
+\begin{samepage}
+    \begin{exercise}
+    Match equations $y'=\sin x$, $y'=\cos y$, $y' = y\cos(x)$ to slope fields.
+    Justify.
+    \begin{tasks}(3)
+    \task
+    \parbox[c]{1.75in}{\includegraphics[width=1.75in]{figures/yprimecosyslope}}
+    \task
+    \parbox[c]{1.75in}{\includegraphics[width=1.75in]{figures/yprimecosxyslope}}
+    \task
+    \parbox[c]{1.75in}{\includegraphics[width=1.75in]{figures/yprimesinxslope}}
+    \end{tasks}
+    \end{exercise}
+    \end{samepage}
+    \exsol{%
+    a) $y'=\cos y$, \quad
+    b) $y' = y\cos(x)$, \quad
+    c) $y'=\sin x$. \quad
+    Justification left to reader.
+    }
+
+\begin{exercise}
+Is it possible to solve the equation $y' = \frac{xy}{\cos x}$ for $y(0) = 1$?
+Justify.
+\end{exercise}
+\exsol{%
+$f(x,y)$ is continuous near $(0,1)$ and $\frac{\partial f}{\partial y}=\frac{x}{\cos x}$ exists and is continuous near  $(0,1)$, therefore by Picard's theorem a unique solution exists.
+}
+
+\begin{exercise}
+Is it possible to solve the equation $y' = y\sqrt{\lvert x\rvert}$ for
+$y(0) = 0$?  Is the solution unique?
+Justify.
+\end{exercise}
+\exsol{%
+$f(x,y)$ is continuous near $(0,0)$ and $\frac{\partial f}{\partial y}=\sqrt{|x|}$ exists and is continuous near  $(0,0)$, therefore by Picard's theorem a unique solution exists.
+}
+
 
 \begin{exercise}[challenging]
 Take $y' = f(x,y)$, $y(0) = 0$, where $f(x,y) > 1$
@@ -671,6 +778,9 @@ for all $x$ and $y$.  If
 the solution exists for all $x$, can you say
 what happens to $y(x)$ as $x$ goes to positive infinity?  Explain.
 \end{exercise}
+\exsol{%
+The slope field for this equation would have slopes of at least one everywhere as $f(x,y)>1$ for all $x$ and $y$, so with an initial condition $(0,0)$ a solution would pass through the origin and keep on increasing forever. Thus as $x\rightarrow \infty$, $y\rightarrow \infty$.
+}
 
 \begin{exercise}[challenging]
 Take $(y-x)y' = 0$, $y(0) = 0$.
@@ -679,6 +789,10 @@ Take $(y-x)y' = 0$, $y(0) = 0$.
 \task Explain why this does not violate Picard's theorem.  
 \end{tasks}
 \end{exercise}
+\exsol{%
+a) $y=0,\quad y=x$\\
+b) The DE cannot be written in the form $y'=f(x,y)$, so Picard's theorem does not apply. 
+}
 
 \begin{exercise}
 Suppose $y' = f(x,y)$.  What will the slope field look like, explain and
@@ -696,6 +810,9 @@ number $t$.
 \begin{exercise}
 Find a solution to $y' = \lvert y \rvert$, $y(0) = 0$.  Does Picard's theorem apply?
 \end{exercise}
+\exsol{%
+$y=0$ is a solution. $f(x,y)$ is continuous but $\frac{\partial f}{\partial y}$ does not exist near $(0,0)$, so Picard's theorem does not apply. 
+}
 
 \begin{exercise}
 Take an equation $y' = (y-2x) g(x,y) + 2$ for some function $g(x,y)$.
@@ -703,6 +820,9 @@ Can you solve the problem for the
 initial condition $y(0) = 0$,
 and if so what is the solution?
 \end{exercise}
+\exsol{%
+$y=2x$
+}
 
 \begin{exercise}[challenging]
 \pagebreak[2]
@@ -721,8 +841,13 @@ Given $y(0) = 0$, what can you say about the solution.  In particular,
 can $y(x) > 1$ for any $x$?  Can $y(x) = 1$ for any $x$?  Why or why not?
 \end{tasks}
 \end{exercise}
+\exsol{%
+a) $y=1$ \\
+b) No. As this satisfies the conditions of Picard's Theorem everywhere, there must be a unique solution from any given points. Thus two different solutions at the same point is not possible as that point can be taken as the initial condition.  \\
+c) Since $y=1$ is one solution for a different initial condition, by part (b), any other solution cannot intersect that. Given that the initial condition here $y(0)=0$ is below the $y(x)=1$ line, the solution can never intersect with 1, thus $y(x)< 1$ for all $x$.
+}
 
-\setcounter{exercise}{100}
+
 
 \begin{exercise}
 Sketch the slope field of $y'=y^3$.  Can you visually find the solution
@@ -752,26 +877,7 @@ Is it possible to solve $y' = \frac{x}{x^2-1}$ for $y(1) = 0$?
 No, the equation is not defined at $(x,y) = (1,0)$.
 }
 
-\begin{samepage}
-\begin{exercise}
-Match equations $y'=\sin x$, $y'=\cos y$, $y' = y\cos(x)$ to slope fields.
-Justify.
-\begin{tasks}(3)
-\task
-\parbox[c]{1.75in}{\includegraphics[width=1.75in]{figures/yprimecosyslope}}
-\task
-\parbox[c]{1.75in}{\includegraphics[width=1.75in]{figures/yprimecosxyslope}}
-\task
-\parbox[c]{1.75in}{\includegraphics[width=1.75in]{figures/yprimesinxslope}}
-\end{tasks}
-\end{exercise}
-\end{samepage}
-\exsol{%
-a) $y'=\cos y$, \quad
-b) $y' = y\cos(x)$, \quad
-c) $y'=\sin x$. \quad
-Justification left to reader.
-}
+
 
 \begin{exercise}[tricky]
 Suppose
@@ -809,8 +915,7 @@ exist for every $x$.
 \section{Separable equations}
 \label{separable:section}
 
-\sectionnotes{1 lecture\EPref{, \S1.4 in \cite{EP}}\BDref{,
-\S2.2 in \cite{BD}}}
+
 
 When a differential equation is of the form
 $y' = f(x)$,
@@ -826,6 +931,10 @@ y = \int f(x,y) \,dx + C .
 Notice the dependence on $y$ in the integral.
 
 \subsection{Separable equations}
+
+\begin{video}[RSLQvrzpdMQ][Separation of Variables][first-separable]
+	In this video we learn our first main of solving ODEs beyond just integrating, and it applies to so called separable ODEs.
+\end{video}
 
 We say a differential equation is
 \emph{\myindex{separable}}
@@ -1002,6 +1111,14 @@ y = \tan \left(\frac{-1}{x} - x + 2 \right) .
 \end{equation*}
 \end{example}
 
+\begin{video}[6JLG8uVWNHU][Newton's Law of Cooling][first-Newton]
+	In this example we investigate the modelling process to determine the temperature on a cooling object like a cup of tea. The ODE we come up with is separable, and so this gives us a nice second example. However, we have to collect a bit more data than just an initial condition because our model has some undetermined parameter in it. 
+\end{video}
+
+
+
+
+
 \begin{example} \label{sep:coffeeexample}
 Bob made a cup of coffee, and
 Bob likes to drink coffee only once reaches 60 degrees Celsius and will not burn him.
@@ -1083,56 +1200,129 @@ y = \frac{6}{x^2 + 2C}, \qquad \text{and} \qquad y=0 .
 \begin{exercise}
 Solve $y' = \nicefrac{x}{y}$.
 \end{exercise}
+\exsolution{%
+Rearranging we get
+\[
+\int ydy=\int xdx
+\]
+\[
+\frac{y^2}{2}=\frac{x^2}{2}+c
+\]
+Solving for $y$
+\[
+y=\sqrt{x^2+c}\quad \textrm{or}\quad y=-\sqrt{x^2+c}
+\]
+The choice of sign would depend on initial conditions. 
+}
 
 \begin{exercise}
 Solve $y' = x^2y$.
 \end{exercise}
+\exsol{%
+$y=Ce^{x^3/3}$
+}
 
 \begin{exercise}
 Solve $\dfrac{dx}{dt} = (x^2-1)\,t$, for $x(0) = 0$.
 \end{exercise}
+\exsol{%
+$x=\tanh \left(\frac{-t^2}{2}\right)=-\frac{e^{t^2}-1}{e^{t^2}+1}$
+}
 
 \begin{exercise}
 Solve $\dfrac{dx}{dt} = x\,\sin(t)$, for $x(0) = 1$.
 \end{exercise}
+\exsolution{%
+Rearranging 
+\[
+\int \frac{dx}{x}=\int \sin(t)dt\rightarrow \ln \lvert x \rvert =-\cos t+c
+\]
+Applying the initial condition $x(0)=1$ we get $c=1$.  Therefore
+\[
+\lvert x \rvert =e^{1-\cos(t)} \rightarrow x=\pm e^{1-\cos(t)}
+\]
+Checking the initial condition again $x(0)=\pm e^0=\pm 1$ so we choose the positive sign. Thus
+\[
+x=e^{1-\cos(t)}
+\]
+}
 
 \begin{exercise}
 Solve $\dfrac{dy}{dx} = xy+x+y+1$.  Hint: Factor the right-hand side.
 \end{exercise}
+\exsol{%
+$y=Ce^{x^2/2+x}-1$
+}
 
 \begin{exercise}
 Solve $xy' = y + 2x^2 y$, where $y(1) = 1$.
 \end{exercise}
+\exsol{%
+$y=\lvert x \rvert e^{x^2-1}$
+}
 
 \begin{exercise}
 Solve $\dfrac{dy}{dx} = \dfrac{y^2+1}{x^2+1}$, for $y(0) = 1$.
 \end{exercise}
+\exsol{%
+$y=\tan \left(\arctan(x)+\frac{\pi}{4}\right)$
+}
 
 \begin{exercise}
 Find an implicit solution for
 $\dfrac{dy}{dx} = \dfrac{x^2+1}{y^2+1}$, for $y(0) = 1$.
 \end{exercise}
+\exsolution{%
+Rearranging
+\[
+\int y^2+1 dy=\int x^2+1 dx\rightarrow \frac{y^3}{3}+y=\frac{x^3}{3}+x+c
+\]
+Applying the initial condition $y(0)=1$ we get $c=\frac{4}{3}$. Thus the implicit solution is
+\[
+\frac{y^3}{3}+y=\frac{x^3}{3}+x+\frac{4}{3}
+\]
+}
 
 \begin{exercise}
 Find an explicit solution for $y' = xe^{-y}$, $y(0)=1$.
 \end{exercise}
+\exsol{%
+$y=\ln(\frac{x^2}{2}+e)$
+}
 
 \begin{exercise}
 Find an explicit solution for $xy' = e^{-y}$, for $y(1)=1$.
 \end{exercise}
+\exsol{%
+$y=\ln\left(\ln \lvert x \rvert +e\right)$
+}
 
 \begin{exercise}
 Find an explicit solution for $y' = ye^{-x^2}$, $y(0)=1$.  It is alright to
 leave a definite integral in your answer.
 \end{exercise}
+\exsol{%
+$y=e^{\int e^{-x^2}dx}$. It is implied that the integral doesn't have an integration constant. A proper way to write this would be  $y=e^{\int_0^x e^{-t^2}dt}$
+}
 
 \begin{exercise}
 Suppose a cup of coffee is at 100 degrees Celsius at time $t=0$,
 it is at 70 degrees at $t=10$ minutes, and it is at 50 degrees at $t=20$
 minutes.  Compute the ambient temperature.
 \end{exercise}
-
-\setcounter{exercise}{100}
+\exsolution{%
+Applying the three conditions to the equation 
+\[
+T=A+De^{-kT}
+\]
+We get a system of three equations
+\begin{align*}
+100=& A+D \\
+70=& A+De^{-10k} \\
+50=& A+De^{-20k}
+\end{align*}
+Solving this system we get $A=10^{\circ}$ C (and $D=90$, $k\approx 0.0405$).
+}
 
 \begin{exercise}
 Solve $y'=2xy$.
@@ -1207,8 +1397,9 @@ a) $x = \frac{1000e^t}{e^t+24}$. \quad b) 102 rabbits after one month,
 \section{Linear equations and the integrating factor}
 \label{intfactor:section}
 
-\sectionnotes{1 lecture\EPref{, \S1.5 in \cite{EP}}\BDref{,
-\S2.1 in \cite{BD}}}
+\begin{video}[5DdXrMcbNIM][Linear Equations and Integrating Factors][first-linear]
+    In section \sectionref{slopefields:section} we saw existence and uniqueness for a completely general first order ODE. In \sectionref{separable:section} last class we saw separable differential equations which is a specific class of first order ODEs. Now in section 1.4 we are seeing a different class of ODEs called linear ODEs, and they are particularly nice because they come with a method that always works (provided you can evaluate the integrals) to solve the ODE.  We will also see that this comes with a particularly nice Existence & Uniqueness theorem that is stronger than the one for generic ODEs. 
+\end{video}
 
 One of the most important types of equations we will learn how to solve are
 the so-called
@@ -1301,11 +1492,10 @@ $e^{\int p(x) dx}$.  You can always add a constant of integration,
 but those constants
 will not matter in the end.
 
-\begin{exercise}
-Try it!  Add a constant of integration to the integral in
+Exercise: Try it!  Add a constant of integration to the integral in
 the integrating factor and show that the solution you get in the end is the
 same as what we got above.
-\end{exercise}
+
 
 Advice: Do not try to remember the formula itself, that is way too
 hard.  It is easier to remember the process and repeat it.
@@ -1332,18 +1522,20 @@ be careful to properly use dummy variables here.  If you now plug such a
 formula into a
 computer or a calculator, it will be happy to give you numerical answers.
 
-\begin{exercise}
-Check that $y(x_0) = y_0$ in formula \eqref{lei:defsol}.
-\end{exercise}
+\begin{video}[DCbNl-VVsuE][Integrating Factor Examples][first-linear2]
+    Let's work through a full example. 
+\end{video}
 
-\begin{exercise}
-Write the solution of the following problem
+Exercise: Check that $y(x_0) = y_0$ in formula \eqref{lei:defsol}.
+
+
+Exercise: Write the solution of the following problem
 as a definite integral, but try to simplify as far as you can.  You will not
 be able to find the solution in closed form.
 \begin{equation*}
 y' + y = e^{x^2-x}, \qquad y(0) = 10 .
 \end{equation*}
-\end{exercise}
+
 
 \begin{remark}
 Before we move on, we should note some interesting properties of linear
@@ -1521,22 +1713,71 @@ solution, you should give that.
 \begin{exercise}
 Solve $y' + xy = x$.
 \end{exercise}
+\exsolution{%
+\begin{align*}
+p(x)=x,\quad f(x)=x,\quad r(x)=e^{\int x dx}=e^{x^2/2}
+\end{align*}
+so we get
+\begin{align*}
+\frac{d}{dx}\left[e^{x^2/2}y\right]=xe^{x^2/2}
+\end{align*}
+Integrating
+\begin{align*}
+e^{x^2/2}y=e^{x^2/2}+c \rightarrow y=ce^{-x^2/2}+1
+\end{align*}
+}
 
 \begin{exercise}
 Solve $y' + 6y = e^x$.
 \end{exercise}
+\exsol{%
+$y=\frac{e^x}{7}+ce^{-6x}$
+}
 
 \begin{exercise}
 Solve $y' + 3x^2y = \sin(x) \, e^{-x^3}$, with $y(0) = 1$.
 \end{exercise}
+\exsolution{%
+\begin{align*}
+p(x)=3x^2,\quad f(x)=\sin(x)e^{-x^3},\quad r(x)=e^{\int 3x^2dx}=e^{x^3}
+\end{align*}
+Multiplying by the integrating factor and integrating
+\begin{align*}
+e^{x^3}y=-\cos x +c
+\end{align*}
+Applying the initial condition $y(0)=1$ we get $c=2$, therefore
+\begin{align*}
+y=e^{-x^3}(2-\cos x)
+\end{align*}
+}
 
 \begin{exercise}
 Solve $y' + \cos (x) y = \cos(x)$.
 \end{exercise}
+\exsol{%
+$y=1+ce^{-\sin x}$
+}
 
 \begin{exercise}
 Solve $\frac{1}{x^2+1} \, y' + x y = 3$, with $y(0) = 0$.
 \end{exercise}
+\exsol{%
+\begin{align*}
+p(x)=x^3+x,\quad f(x)=3(x^2+1),\quad r(x)=e^{x^4/4+x^2/2}
+\end{align*}
+Multiplying by the integrating factor and integrating 
+\begin{align*}
+e^{x^4/4+x^2/2}y=\int 3(x^2+1)e^{x^4/4+x^2/2}dx
+\end{align*}
+This integral doesn't have a closed form, so it is left as a definite integral 
+\begin{align*}
+y=e^{x^4/4+x^2/2}\int_0^x3(t^2+1)e^{t^4/4+t^2/2} dt +y_0
+\end{align*}
+Applying the initial condition $y(0)=0$ we get $y_0=0$ so finally
+\begin{align*}
+y=e^{x^4/4+x^2/2}\int_0^x3(t^2+1)e^{t^4/4+t^2/2} dt
+\end{align*}
+}
 
 \begin{exercise}
 Suppose there are two lakes located on a stream.  Clean
@@ -1558,6 +1799,51 @@ concentration in the first lake be below \unit[0.001]{kg} per liter?
 concentration in the second lake be maximal?
 \end{tasks}
 \end{exercise}
+\exsolution{%
+(a) Lake 1: 
+\begin{align*}
+x &= \textrm{kg of toxic material} \\
+\textrm{rate in} &=\textrm{rate out}=500 \\
+\textrm{concentration in} &=0 \\
+\textrm{concenctraiton out} &= \frac{x}{V_1}=\frac{x}{10^5}
+\end{align*}
+\begin{align*}
+\frac{dx}{dt}=-500\frac{x}{10^5}\rightarrow \ln x=-\frac{t}{200}
+\end{align*}
+\begin{align*}
+x=x_0e^{-t/200}
+\end{align*}
+Applying the initial condition $x(0)=x_0=500$ the equation becomes
+\[
+x(t)=500e^{-t/200}
+\]
+Lake 2:
+\begin{align*}
+\frac{dx_2}{dt}& =\frac{x_1(t)}{200}-\frac{x_2(t)}{400} \\
+\frac{dx_2}{dt}& =\frac{5e^{-t/200}}{2}-\frac{x_2(t)}{400} \\
+\end{align*}
+Where 
+\[
+p(t)=\frac{1}{400},\quad f(t)=\frac{5e^{-t/200}}{2},\quad r(t)=e^{t/400}
+\]
+Multiplying and integrating
+\[
+e^{t/400}x_2=-1000e^{-t/400}+c
+\]
+Applying the initial condition $x_2(0)=0$ we find $c=1000$ so
+\[
+x_2=1000(e^{-t/400}-e^{-t/200})
+\]
+(b) At concentration $=0.001\rightarrow x=100$ kg. Plugging into the solution for the first lake
+\[
+100=500e^{-t_f/200}\rightarrow t_f\approx 321.89 \rm hours
+\]
+(c) The critical point can be obtained by setting the first derivative to zero
+\[
+\frac{dx_2}{dt}=1000(-\frac{1}{400}e^{-t/400}+\frac{1}{200}e^{-t/200})=0
+\]
+Solving for $t$ we find $t=-400\ln\frac{1}{2}\approx 277.26$ hours.
+}
 
 \begin{exercise}
 \myindex{Newton's law of cooling} states that $\frac{dx}{dt} = -k(x-A)$ where
@@ -1572,6 +1858,31 @@ temperatures).
 initial conditions make much of a difference?  Why or why not?
 \end{tasks}
 \end{exercise}
+\exsolution{%
+(a) \[
+x'=-kx+kA_0\cos(\omega t)
+\]
+\[
+p(t)=k,\quad f(t)=kA_0\cos(\omega t),\quad r(t)=e^{kt}
+\]
+Multiplying and integrating
+\begin{equation*}
+    e^{kt}x=kA_0\int e^{kt}\cos(\omega t)dt=kA_0 e^{kt}\left(\frac{k\cos(\omega t)+\omega\cos(\omega t)}{k^2+\omega^2}\right)+C
+\end{equation}
+    \begin{equation*}
+x(t)=kA_0\left(\frac{k\cos(\omega t)+\omega \sin(\omega t)}{k^2+\omega^2}\right)+Ce^{-kt}
+\end{equation*}
+(b)
+In the long term, $t$ becomes large, so the $e^{-kt}$ term vanishes. The initial condition is 
+\begin{equation*}
+x(0)=x_0=\frac{k^2A_0}{k^2+\omega^2}+C
+\end{equation*}
+So we can write the solution as
+\begin{equation*}
+x(t)=kA_0\left(\frac{k\cos(\omega t)+\omega \sin(\omega t)}{k^2+\omega^2}\right)+\left(x_0-\frac{k^2A_0}{k^2+\omega^2}\right)e^{-kt}
+\end{equation*}
+Where the last term vanishes at large $t$, and so the initial condition $x_0$ doesn't matter. 
+}
 
 \begin{exercise}
 Initially 5 grams of salt are dissolved in 20 liters of water.  Brine
@@ -1580,6 +1891,9 @@ of 3 liters a minute.  The tank is mixed well and is drained at 3 liters
 a minute.  How long does the process have to continue until there are 20 grams
 of salt in the tank?
 \end{exercise}
+\exsol{%
+The solution is $x(t)=40-35e^{-3t/20}$, plugging in the values given, we get $t\approx 3.73$ minutes.
+}
 
 \begin{exercise}
 Initially a tank contains 10 liters of pure water.
@@ -1589,8 +1903,10 @@ The water is mixed well and drained at 1 liter per minute.
 In 20 minutes there are 15 grams of salt in the tank.  What is the
 concentration of salt in the incoming brine?
 \end{exercise}
+\exsol{%
+The solution is $x(t)=10k+ce^{-t/10}$, where $k$ is the concentration and $c$ is the integration constant. Plugging in the given values we find $k\approx 1.735$ g/L.
+}
 
-\setcounter{exercise}{100}
 
 \begin{exercise}
 Solve $y'+3 x^2 y = x^2$.
@@ -1649,9 +1965,6 @@ $Ah' = I - kh$, where $k$ is a constant with units $\unitfrac{m^2}{s}$.
 \sectionnewpage
 \section{Substitution}
 \label{substitution:section}
-
-\sectionnotes{1 lecture, can safely be skipped\EPref{, \S1.6 in \cite{EP}}\BDref{, not in
-\cite{BD}}}
 
 Just as when solving integrals, one method to try is to change variables to
 end up with a simpler equation to solve.
@@ -1732,6 +2045,10 @@ of thumb.  You might have to modify your guesses.  If a substitution
 does not work (it does not make the equation any simpler), try a different one.
 
 \subsection{Bernoulli equations}
+
+\begin{video}[MxI-XktO-go][Bernoulli equations][first-bernoulli]
+    We have two major classes that we have procedures to solve - separable and linear ODEs. However, we can often use a substitution to convert a different type of ODE into one of these two types. In this video we use a substitution to solve a major class of ODEs called Bernoulli equations
+\end{video}
 
 There are some forms of equations where there is a
 general rule for substitution that always works.
@@ -1876,28 +2193,104 @@ Hint: Answers need not always be in closed form.
 Solve
 $y'+ y(x^2-1)+xy^6 = 0$, with $y(1)=1$.
 \end{exercise}
+\exsolution{%
+This is a Bernoulli equation with $n=6$. So we substitute $v=y^{-5}$, $v'=-5y^{-6}y'$ and get \[
+v'-5v(x^2-1)=5x
+\]
+A linear ODE with 
+\[
+p(x)=-5(x^2-1),\quad f(x)=5x,\quad r(x)=e^{-\frac{5x^3}{3}+5x}
+\]
+Multiplying and integrating
+\[
+e^{-\frac{5x^3}{3}+5x}v=\int 5xe^{-\frac{5x^3}{3}+5x} dx
+\]
+This integral doesn't have a closed form. Applying the initial condition $y(1)=1\ \rightarrow\ v(1)=1$
+\[
+v=e^{\frac{5x^3}{3}-5x}\left(\int_1^x 5te^{-\frac{5t^3}{3}+5t}dt +1\right) 
+\]
+\begin{equation}
+y=\sqrt[5]{\frac{1}{e^{\frac{5x^3}{3}-5x}\left(\int_1^x 5te^{-\frac{5t^3}{3}+5t}dt +1\right) }}
+\end{equation}
+}
 
 \begin{exercise}
 Solve $2yy' + 1 = y^2 + x$, with $y(0)=1$.
 \end{exercise}
+\exsolution{%
+Try $v=y^2$ giving $v'=2yy'$. Substituting 
+\[
+v'+1=v+x \quad \rightarrow v'-v=x-1
+\]
+A linear ODE with 
+\[
+p(x)=-1,\quad f(x)=x-1,\quad r(x)=e^{-x}
+\]
+Multiplying and integrating
+\[
+e^{-x}v=-xe^{-x}+c
+\]
+Applying the initial condition $y(0)=1\ \rightarrow v(0)=1$, giving $c=1$. Thus we write
+\[
+v=-x+e^x
+\]
+\[
+y=\sqrt{e^x-x}
+\]
+}
 
 \begin{exercise}
 Solve $y' + xy = y^4$, with $y(0)=1$.
 \end{exercise}
+\exsol{%
+$y=\sqrt[3]{\frac{1}{e^{\frac{3x^2}{2}}\left(\int_0^x -3e^{\frac{-3t^2}{2}}dt+1\right)}}$
+}
 
 \begin{exercise}
 Solve $yy' + x = \sqrt{x^2 + y^2}$.
 \end{exercise}
+\exsolution{%
+This can be rewritten as  
+\[
+y'=\sqrt{\left(\frac{x}{y}\right)^2+1}-\frac{x}{y}
+\]
+\[
+y=\sqrt{\left( \frac{1}{y/x}\right)^2+1}-\frac{1}{y/x}=F(y/x)
+\]
+This is a homogeneous equation, so we substitute $v=y/x$. Following through with the substitution  
+\[
+\int \frac{1}{F(v)-v}dv=ln\lvert x\rvert +c
+\]
+\[
+\int \frac{1}{\sqrt{\frac{1}{v^2}+1}-\frac{1}{v}-v}dv=ln\lvert x\rvert +x
+\]
+Integrating
+\[
+\lvert 1-\sqrt{v^2+1}\rvert = c\lvert \frac{1}{x}\rvert 
+\]
+\[
+v=\sqrt{(1-c\lvert \frac{1}{x}\rvert)^2-1}=\sqrt{\frac{c^2}{x^2}-2c\lvert \frac{1}{x}\rvert}
+\]
+\[
+y=\sqrt{c^2-2c\lvert x \rvert}
+\]
+}
 
 \begin{exercise}
 Solve $y' = {(x+y-1)}^2$.
 \end{exercise}
+\exsol{%
+$y=\sqrt{\tan (x+c)}-x+1$
+}
 
 \begin{exercise}
 Solve $y' = \frac{x^2-y^2}{x y}$, with $y(1) = 2$.
 \end{exercise}
+\exsol{%
+$y=x\sqrt{\frac{1}{2}+\frac{7}{2x^4}}$
+}
 
-\setcounter{exercise}{100}
+
 
 \begin{exercise}
 Solve $xy'+y+y^2 = 0$, $y(1)=2$.
@@ -1933,8 +2326,9 @@ $y = \sqrt{x^2-\ln(C-x)}$
 \section{Autonomous equations}
 \label{auteq:section}
 
-\sectionnotes{1 lecture\EPref{, \S2.2 in \cite{EP}}\BDref{,
-\S2.5 in \cite{BD}}}
+\begin{video}[LSzos_8Ht1s][Autonomous Equations][first-autonomous]
+    An Autonomous equation $y'=f(y)$ ONLY depends on the dependent variable. This simplification allows a lot of special types of analysis such as equilibrium values, stability, and what happens as t gets large. 
+\end{video}
 
 Consider
 problems of the form
@@ -1996,6 +2390,10 @@ as $t \to \infty$.  If a critical point is not stable, we say it is
 \end{myfig}
 
 \medskip
+
+\begin{video}[yJG434tCeA4][Logistic Equation][first-logistic]
+    Exponential growth is great and all, but is it realistic that biological systems grow unbounded forever? In this video we will explore modelling with Logistic Growth to account for this difficulty. 
+\end{video}
 
 Consider now the \emph{\myindex{logistic equation}}
 \begin{equation*}
@@ -2071,11 +2469,10 @@ moves from left to right,
 the graph of a solution
 goes up if the arrow is up, and it goes down if the arrow is down.
 
-\begin{exercise}
-Try sketching a few solutions simply from looking at the phase diagram.
+Exercise: Try sketching a few solutions simply from looking at the phase diagram.
 Check with the preceding graphs if
 you are getting the type of curves.
-\end{exercise}
+
 
 \pagebreak[0]
 Once we draw the phase diagram, we classify critical points
@@ -2119,12 +2516,11 @@ A = \frac{kM + \sqrt{{(kM)}^2 - 4hk}}{2k}, \qquad
 B = \frac{kM - \sqrt{{(kM)}^2 - 4hk}}{2k} .
 \end{equation*}
 
-\begin{exercise}
-Sketch a phase diagram for different possibilities.  Note
+Exercise: Sketch a phase diagram for different possibilities.  Note
 that these possibilities are $A > B$, or $A=B$, or $A$ and $B$ both complex
 (i.e.\ no real solutions).  Hint: Fix some simple $k$ and $M$ and then vary
 $h$.
-\end{exercise}
+
 
 For example, let $M=8$ and $k=0.1$.
 When $h=1$, then $A$ and $B$ are distinct and positive.
@@ -2226,6 +2622,19 @@ the equation is still logistic.
 \task What happens when $kM < h$?
 \end{tasks}
 \end{exercise}
+\exsolution{%
+(a) $\frac{dx}{dt}=kx(M-x)-hx$ \\
+(b) Rearranging
+\[
+\frac{dx}{dt}=kx\left(\frac{kM-h}{k}-x\right)
+\]
+The term $\frac{kM-h}{k}>0$ in this case, and we cane rename it to $N$ making the equation
+\[
+\frac{dx}{dt}=kx(N-x)
+\]
+With $k$ and $N$ positive, making this the logistic equation again. \\
+(c) If $kM<0$ then $N<0$, so the critical points are at $x=0$ and $x=-N$. The latter point can be ignored since the population can only be positive. Substituting positive x values in $kx(N-x)$ gives negative values, hence $\displaystyle \lim_{t\to\infty} x(t)=0$, i.e. the population collapses. 
+}
 
 \begin{exercise}
 A disease is spreading through the country.  Let $x$ be the number of people
@@ -2241,9 +2650,13 @@ $\displaystyle \lim_{t\to\infty} x(t)$.
 \task Does the solution to part b) agree with your intuition?  Why or why not?
 \end{tasks}
 \end{exercise}
+\exsol{%
+(a) $\frac{dx}{dt}=kx(S-x)$ \\
+(b) $\displaystyle \lim_{t\to\infty}x(t)=S$ \\
+(c) It does, since the solution in part (b) says that if initially some population is infected, this will lead to the number of infected people ($x(t)$) to become equal to the whole susceptible population ($S$) after a long time. This is a reasonable expectation. 
+}
 
 
-\setcounter{exercise}{100}
 
 \begin{exercise}
 Let $x'=(x-1)(x-2)x^2$.
@@ -2500,13 +2913,12 @@ are lucky, we can estimate the error from a few of these calculations and the
 assumption that the error goes down by a factor of one half each time (if
 we are using standard Euler).
 
-\begin{exercise}
+Exericse:
 In the table above, suppose you do not know the error.  Take
 the approximate values of the function in the last two lines,
 assume that the error goes down by a factor of 2.  Can you estimate the
 error in the last time from this?  Does it (approximately) agree with the
 table?  Now do it for the first two rows.  Does this agree with the table?
-\end{exercise}
 
 Let us talk a little bit more about the example
 $y' = \nicefrac{y^2}{3}$, $y(0) =
@@ -2668,7 +3080,7 @@ $y(1)$, and compare.
 \end{tasks}
 \end{exercise}
 
-\setcounter{exercise}{100}
+
 
 \begin{exercise}
 Let $x' = \sin(xt)$, and $x(0)=1$.
@@ -2927,11 +3339,10 @@ for $y$ in terms of $x$.  In this case, we obtain $y = \pm \sqrt{C^2-x^2}$
 as we did before.
 \end{example}
 
-\begin{exercise}
-Why did we not need to add a constant of integration when integrating $A'(y)
+Exercise: Why did we not need to add a constant of integration when integrating $A'(y)
 = 2y$?  Add a constant of integration, say $3$, and see what $F$ you get.
 What is the difference from what we got above, and why does it not matter?
-\end{exercise}
+
 
 
 
@@ -3359,7 +3770,7 @@ find the corresponding harmonic conjugates $v$:
 \end{exercise}
 \end{samepage}
 
-\setcounter{exercise}{100}
+
 
 \begin{exercise}
 Solve the following exact equations, implicit general solutions
@@ -3437,7 +3848,7 @@ $F(x,y) = C$ leads to the same solution as the example.
 \section{First order linear PDE}
 \label{fopde:section}
 
-\sectionnotes{1 lecture, can safely be skipped}
+
 
 We only considered ODE so far, so let us solve a linear first order
 PDE\@.  Consider the equation
@@ -3787,7 +4198,6 @@ Solve $(1+x^2) u_t + x^2 u_x + e^x u = 0$, $u(x,0) = 0$.
 Hint: Think a little out of the box.
 \end{exercise}
 
-\setcounter{exercise}{100}
 
 \begin{exercise}
 Solve

--- a/ch-first-order-ode.tex
+++ b/ch-first-order-ode.tex
@@ -261,13 +261,13 @@ What if we say $x' = v$.  Then we have the problem
 \begin{equation*}
 v' = t^2, \qquad v(0) = 10 .
 \end{equation*}
-Once we solve for $v$, we can integrate and find $x$.
+Once we solve for $v$, we can integrate and find $x$. Do this as an exercise. 
 \end{example}
 
-\begin{exercise}
-Solve for $v$, and then solve for $x$.  Find $x(10)$ to answer the
-question.
-\end{exercise}
+%\begin{exercise}
+%Solve for $v$, and then solve for $x$.  Find $x(10)$ to answer the
+%question.
+%\end{exercise}
 
 \subsection{Exercises}
 
@@ -386,7 +386,7 @@ question.
     }
     
     
-    \setcounter{exercise}{100}
+
     
     \begin{exercise}
     Solve $\frac{dy}{dx} = e^x + x$ and $y(0) = 10$.
@@ -564,6 +564,11 @@ looking at the slope field itself.
 \diffyincludegraphics{width=3in}{width=4.5in}{1-3-mysl-sol}
 \caption{Slope field of $y' = -y$ with a graph of a few solutions.\label{1.3:fig3}}
 \end{myfig}
+
+
+\begin{example}
+\emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/zjfhbkqe}{this Geogebra slope field plotter} to explore the slope fields of several first order differential equations and play around with the solutions starting at different initial conditions. 
+\end{example}
 
 \subsection{Existence and uniqueness}
 
@@ -1176,6 +1181,12 @@ $t \approx 9.21$.  On the right, the graph is over a longer period of time,
 with a horizontal line at the ambient temperature 22.\label{sintro:coffeefig}}
 \end{myfig}
 \end{example}
+
+
+\begin{example}
+    \emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/n7byk5wt}{this Geogebra applet}  to explore Newton's Law of Cooling. Try a few different initial conditions and explore how they affect the cooling curve. You can use this application as a check when solving problems involving Newton cooling.
+\end{example}
+
 
 \begin{example}
 Find the general solution to $y' = \frac{-xy^2}{3}$ (including singular
@@ -1791,7 +1802,7 @@ A truck with \unit[500]{kg} of toxic substance
 crashes into the first lake.  Assume that the water is being continually
 mixed perfectly by the stream.
 \begin{tasks}
-\task Find the concentration of toxic substance
+\task Find the mass of toxic substance
 as a function of time in both lakes.
 \task When will the
 concentration in the first lake be below \unit[0.001]{kg} per liter?
@@ -1802,21 +1813,23 @@ concentration in the second lake be maximal?
 \exsolution{%
 (a) Lake 1: 
 \begin{align*}
-x &= \textrm{kg of toxic material} \\
-\textrm{rate in} &=\textrm{rate out}=500 \\
+x_1 &= \textrm{kg of toxic material in Lake 1} \\
+\textrm{rate in} &=\textrm{rate out}=500L/h \\
 \textrm{concentration in} &=0 \\
-\textrm{concenctraiton out} &= \frac{x}{V_1}=\frac{x}{10^5}
+\textrm{concentration out} &= \frac{x_1}{V_1}=\frac{x_1}{10^5}
 \end{align*}
 \begin{align*}
-\frac{dx}{dt}=-500\frac{x}{10^5}\rightarrow \ln x=-\frac{t}{200}
+\frac{dx_1}{dt}=-500\frac{x_1}{10^5}\rightarrow \ln x_1=-\frac{t}{200}
 \end{align*}
 \begin{align*}
-x=x_0e^{-t/200}
+x_1=x(0)e^{-t/200}
 \end{align*}
-Applying the initial condition $x(0)=x_0=500$ the equation becomes
+Applying the initial condition $x(0)=500\textrm{kg}$ the equation becomes
 \[
-x(t)=500e^{-t/200}
+x_1(t)=500e^{-t/200}
 \]
+
+
 Lake 2:
 \begin{align*}
 \frac{dx_2}{dt}& =\frac{x_1(t)}{200}-\frac{x_2(t)}{400} \\
@@ -1828,9 +1841,9 @@ p(t)=\frac{1}{400},\quad f(t)=\frac{5e^{-t/200}}{2},\quad r(t)=e^{t/400}
 \]
 Multiplying and integrating
 \[
-e^{t/400}x_2=-1000e^{-t/400}+c
+e^{t/400}x_2=-1000e^{-t/400}+C
 \]
-Applying the initial condition $x_2(0)=0$ we find $c=1000$ so
+Applying the initial condition $x_2(0)=0$ we find $C=1000$ so
 \[
 x_2=1000(e^{-t/400}-e^{-t/200})
 \]
@@ -1868,8 +1881,8 @@ p(t)=k,\quad f(t)=kA_0\cos(\omega t),\quad r(t)=e^{kt}
 Multiplying and integrating
 \begin{equation*}
     e^{kt}x=kA_0\int e^{kt}\cos(\omega t)dt=kA_0 e^{kt}\left(\frac{k\cos(\omega t)+\omega\cos(\omega t)}{k^2+\omega^2}\right)+C
-\end{equation}
-    \begin{equation*}
+\end{equation*}
+\begin{equation*}
 x(t)=kA_0\left(\frac{k\cos(\omega t)+\omega \sin(\omega t)}{k^2+\omega^2}\right)+Ce^{-kt}
 \end{equation*}
 (b)
@@ -2047,7 +2060,9 @@ does not work (it does not make the equation any simpler), try a different one.
 \subsection{Bernoulli equations}
 
 \begin{video}[MxI-XktO-go][Bernoulli equations][first-bernoulli]
-    We have two major classes that we have procedures to solve - separable and linear ODEs. However, we can often use a substitution to convert a different type of ODE into one of these two types. In this video we use a substitution to solve a major class of ODEs called Bernoulli equations
+    We have two major classes that we have procedures to solve - separable and linear ODEs. However, we can often use a substitution to convert a different type of ODE into one of these two types. In this video we use a substitution to solve a major class of ODEs called Bernoulli equations. 
+
+    TYPO: At 5:25, an $10x$ should be a $10u$. 
 \end{video}
 
 There are some forms of equations where there is a
@@ -2569,6 +2584,27 @@ $x' = 0.1\,x\,(8-x)-2$.\label{2.2:harv2}}
 \end{myfig}
 
 %$dx/dt = 0.1*x*(8-x)-1$, $t: [0,20], x: [-5,10]$,
+
+
+
+\begin{example}
+    \emph{Geogebra Activity:} Try to sketch by hand the phase diagram for each of the following equations, then use \href{https://www.geogebra.org/m/twj2ycb9}{this Geogebra phase diagram plotter} to verify your answers. 
+    
+   \begin{equation*}
+    \frac{dx}{dt}=x^2-9x+4
+   \end{equation*}
+    \begin{equation*}
+        \frac{dx}{dt}=\cos(2x),\ \ -\pi<x<\pi
+    \end{equation*}
+        \begin{equation*}
+            \frac{dx}{dt}=(x-2)^2
+        \end{equation*}
+            \begin{equation*}
+                \frac{dx}{dt}=x^2+2
+            \end{equation*}
+
+
+    \end{example}
 
 \subsection{Exercises}
 

--- a/ch-fourier-and-pde.tex
+++ b/ch-fourier-and-pde.tex
@@ -1211,7 +1211,7 @@ Calculating $b_{n}$ for $n=1$, we find that $b_{1}=1$. Therefore, the Fourier se
 \begin{myfig}
 \capstart
 \diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ3}
-\caption{Periodic Extension of $f(t)=\sin \pi t$ on $(-\pi,\pi]$ \label{FourierSeriesQ3}}
+\caption{Periodic Extension of $f(t)=\sin t$ on $(-\pi,\pi]$ \label{FourierSeriesQ3}}
 \end{myfig}
 \medskip
 }
@@ -1532,6 +1532,20 @@ and up to the ${20}^{\text{th}}$ harmonic (right graph).\label{gfs:sawcontfsfig}
 \end{myfig}
 \end{example}
 
+
+\begin{example}
+	\emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/n88jfkwq}{this Geogebra applet} to explore how the periodic extension looks like for different functions and intervals. 
+	
+	Note: You can define $f(x)$ to be piecewise within the interval by writing \emph{If(x>a,g(x),h(x))} in the input box, which in the usual notation corresponds to 
+\begin{equation*}
+	f(x)=\begin{cases}
+	g(x)\quad x>a \\
+	h(x)\quad x\leq a
+	\end{cases}
+\end{equation*}
+ \end{example}
+
+
 \subsection{Convergence}
 
 \emph{Note: Convergence was covered previously in the video series in \ref{fouriercoefficients}}
@@ -1830,9 +1844,13 @@ the series again, we would obtain
 \end{equation*}
 which does not converge!
 
-Computer Exercise: Use a computer to plot the series we obtained for $f(t)$, $f'(t)$ and
-$f''(t)$.  That is, plot say the first 5 harmonics of the functions.  At what
-points does $f''(t)$ have the discontinuities?
+
+
+\begin{example}
+	\emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/m4wsepwu}{this Geogebra applet} to plot the series for $f(t)$ and the obtained series for its derivatives to see the behaviour described above. Explore this behaviour with your own series and see how fast they (and their derivatives) converge. 
+	
+
+ \end{example}
 
 \subsection{Exercises}
 
@@ -2268,13 +2286,17 @@ Recall that a function $f(t)$ is \emph{odd}\index{odd function} if $f(-t) =
 $f(-t) = f(t)$.  For example, $\cos (n t)$ is even and $\sin (n t)$ is odd.
 Similarly the function $t^k$ is even if $k$ is even and odd when $k$ is odd.
 
-Exercise: Take two functions $f(t)$ and $g(t)$ and define their product $h(t) =
+\begin{example} Take two functions $f(t)$ and $g(t)$ and define their product $h(t) =
 f(t)g(t)$.
 \begin{tasks}
 \task Suppose both $f(t)$ and $g(t)$ are odd.  Is $h(t)$ odd or even?
 \task Suppose one is even and one is odd.  Is $h(t)$ odd or even?
 \task Suppose both are even.  Is $h(t)$ odd or even?
 \end{tasks}
+
+You can check your answers graphically using \href{https://www.geogebra.org/m/hfk7axbg}{this Geogebra applet}. Even functions are symmetric about the y-axis, while odd functions are flip over both the y-axis and the x-axis. 
+
+ \end{example} 
 
 
 If $f(t)$ and $g(t)$ are both odd, then $f(t)+g(t)$ is odd.  Similarly for
@@ -2760,14 +2782,14 @@ Take $f(t) = \sin t$ defined on $0 \leq t \leq \pi$.
 \exsol{%
 a) \begin{myfig}
 \capstart
-\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ7a}
-\caption{Even Periodic Extension of $f(t)=\sin t$ on $[0,\pi]$ \label{FourierSineCosineSeriesQ7a}}
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ7b}
+\caption{Even Periodic Extension of $f(t)=\sin t$ on $[0,\pi]$ \label{FourierSineCosineSeriesQ7b}}
 \end{myfig}
 \medskip
 b) \begin{myfig}
 \capstart
-\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ7b}
-\caption{Odd Periodic Extension of $f(t)=\sin t$ on $[0,\pi]$ \label{FourierSineCosineSeriesQ7b}}
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ7a}
+\caption{Odd Periodic Extension of $f(t)=\sin t$ on $[0,\pi]$ \label{FourierSineCosineSeriesQ7a}}
 \end{myfig}
 \medskip
 }
@@ -3083,9 +3105,7 @@ $F(t)$ itself.  See \figurevref{afs:steadyexfig} for the plot of this solution.
 \begin{myfig}
 \capstart
 \diffyincludegraphics{width=3in}{width=4.5in}{afs-steadyex}
-\caption{Plot of the steady periodic solution $x_{sp}$ of
-\exampleref{afs:steadyex}.%
-\label{afs:steadyexfig}}
+\caption{Plot of the steady periodic solution $x_{sp}$.\label{afs:steadyexfig}}
 \end{myfig}
 \end{example}
 

--- a/ch-fourier-and-pde.tex
+++ b/ch-fourier-and-pde.tex
@@ -4,8 +4,6 @@
 
 \section{Boundary value problems} \label{bvp:section}
 
-\sectionnotes{2 lectures\EPref{, similar to \S3.8 in \cite{EP}}\BDref{,
-\S10.1 and \S11.1 in \cite{BD}}}
 
 \subsection{Boundary value problems}
 
@@ -670,8 +668,10 @@ $\frac{\sqrt{3}}{3} e^{\frac{-3}{2}\sqrt[3]{\lambda}}
 \sectionnewpage
 \section{The trigonometric series} \label{ts:section}
 
-\sectionnotes{2 lectures\EPref{, \S9.1 in \cite{EP}}\BDref{,
-\S10.2 in \cite{BD}}}
+\begin{video}[5-r0hphUNs4][Intro to Fourier Series][fourierintro]
+	In this video we learn how to approximate periodic functions with Fourier Series; that is, a sum of sin and cos terms of different frequencies.	
+\end{video}
+
 
 \subsection{Periodic functions and motivation}
 
@@ -736,90 +736,20 @@ extension and sketch its graph.  How does it compare to the graph of
 $\cos t$?
 \end{exercise}
 
-\subsection{Inner product and eigenvector decomposition}
 
-Suppose we have a \emph{\myindex{symmetric matrix}},
-that is $A^T = A$.  As we remarked before, 
-eigenvectors of $A$ are then orthogonal.  Here the word
-\emph{orthogonal}\index{orthogonal!vectors} means
-that if $\vec{v}$ and $\vec{w}$ are two 
-eigenvectors of $A$ for distinct eigenvalues,
-then $\langle \vec{v} , \vec{w} \rangle = 0$.
-In this case the inner product $\langle \vec{v} , \vec{w} \rangle$
-is the \emph{\myindex{dot product}},
-which can be computed as $\vec{v}^T\vec{w}$.
-
-To decompose a vector $\vec{v}$ in terms of mutually orthogonal
-vectors $\vec{w}_1$ and $\vec{w}_2$ we write
-\begin{equation*}
-\vec{v} = a_1 \vec{w}_1  + a_2 \vec{w}_2 .
-\end{equation*}
-Let us find the formula for $a_1$ and $a_2$.  First let us compute
-\begin{equation*}
-\langle \vec{v} , \vec{w_1} \rangle
-=
-\langle a_1 \vec{w}_1  + a_2 \vec{w}_2 , \vec{w_1} \rangle
-=
-a_1 \langle \vec{w}_1 , \vec{w_1} \rangle
-+
-a_2 \underbrace{\langle \vec{w}_2 , \vec{w_1} \rangle}_{=0}
-=
-a_1 \langle \vec{w}_1 , \vec{w_1} \rangle .
-\end{equation*}
-Therefore,
-\begin{equation*}
-a_1 = 
-\frac{\langle \vec{v} , \vec{w_1} \rangle}{
-\langle \vec{w}_1 , \vec{w_1} \rangle} .
-\end{equation*}
-Similarly
-\begin{equation*}
-a_2 = 
-\frac{\langle \vec{v} , \vec{w_2} \rangle}{
-\langle \vec{w}_2 , \vec{w_2} \rangle} .
-\end{equation*}
-You probably remember this formula from vector calculus.
-
-\begin{example}
-Write
-$\vec{v} = \left[ \begin{smallmatrix} 2 \\ 3 \end{smallmatrix} \right]$
-as a linear combination of 
-$\vec{w_1} = \left[ \begin{smallmatrix} 1 \\ -1 \end{smallmatrix} \right]$
-and
-$\vec{w_2} = \left[ \begin{smallmatrix} 1 \\ 1 \end{smallmatrix} \right]$.
-
-First note that $\vec{w}_1$ and $\vec{w}_2$ are orthogonal
-as $\langle \vec{w}_1 , \vec{w}_2 \rangle = 1(1) + (-1)1 = 0$.
-Then
-\begin{align*}
-& a_1 = 
-\frac{\langle \vec{v} , \vec{w_1} \rangle}{
-\langle \vec{w}_1 , \vec{w_1} \rangle}
-=
-\frac{2(1) + 3(-1)}{1(1) + (-1)(-1)} = \frac{-1}{2} ,
-\\
-& a_2 = 
-\frac{\langle \vec{v} , \vec{w_2} \rangle}{
-\langle \vec{w}_2 , \vec{w_2} \rangle}
-=
-\frac{2 + 3}{1 + 1} = \frac{5}{2} .
-\end{align*}
-Hence
-\begin{equation*}
-\begin{bmatrix} 2 \\ 3 \end{bmatrix}
-=
-\frac{-1}{2}
-\begin{bmatrix} 1 \\ -1 \end{bmatrix}
-+
-\frac{5}{2}
-\begin{bmatrix} 1 \\ 1 \end{bmatrix} .
-\end{equation*}
-\end{example}
 
 \subsection{The trigonometric series}
 
-Instead of decomposing a vector in terms of eigenvectors of a matrix,
-we decompose a function in terms of eigenfunctions of a certain
+\begin{video}[55hgKwHBJXk][Finding the Coefficients & Fourier Convergence Theorem][fouriercoefficients]
+    While in the previous video we had a Fourier Series, we didn't see how to find the coefficients $a_n$ and $b_n$. So our first task is to figure out how to find those. Secondly, we want to answer the question of when a Fourier Series actually converges. 
+\end{video}
+
+\begin{video}[2VXI-pZz8PA][The Linear Algebra Perspective][fourierlinear]
+    If you've taken Linear Algebra, then describing Fourier Series with Linear Algebra terminology and concepts will be very useful at crystalizing all the concepts, but perhaps more importantly it illustrates one of the most important themes in mathematic: how disparate fields can be deeply connected. And if you haven't taken linear algebra, then this is a nice little introduction to some of the ideas of that field. 
+\end{video}
+
+
+Our goal is to decompose a function in terms of eigenfunctions of a certain
 eigenvalue problem.  The eigenvalue problem we use for
 the Fourier series is 
 \begin{equation*}
@@ -1314,8 +1244,7 @@ $\frac{\pi^4}{5} + \sum\limits_{n=1}^\infty
 \section{More on the Fourier series}
 \label{moreonfourier:section}
 
-\sectionnotes{2 lectures\EPref{, \S9.2--\S9.3 in \cite{EP}}\BDref{,
-\S10.3 in \cite{BD}}}
+
 
 %Before reading the lecture, it may be good to first try
 %Project IV (Fourier series)\index{IODE software!Project IV} from the
@@ -1324,6 +1253,9 @@ $\frac{\pi^4}{5} + \sum\limits_{n=1}^\infty
 %Project V (Fourier series again)\index{IODE software!Project V}.
 
 \subsection{$2L$-periodic functions}
+
+
+
 
 We have computed the Fourier series for a $2\pi$-periodic function, but what
 about functions of different periods.  Well, fear not, the computation is a
@@ -1476,6 +1408,8 @@ and up to the ${20}^{\text{th}}$ harmonic (right graph).\label{gfs:sawcontfsfig}
 \end{example}
 
 \subsection{Convergence}
+
+\emph{Note: Convergence was covered previously in the video series in \ref{fouriercoefficients}}
 
 We will need the one sided limits of functions.
 We will use the following notation
@@ -2071,10 +2005,14 @@ f) $F(-9) = 0$
 \section{Sine and cosine series}
 \label{sec:scs}
 
-\sectionnotes{2 lectures\EPref{, \S9.3 in \cite{EP}}\BDref{,
-\S10.4 in \cite{BD}}}
+
 
 \subsection{Odd and even periodic functions}
+
+\begin{video}[-lHP7D6CaV0][Fourier Series Example for an odd function][fouriersodd]
+	We do one more example of computing the Fourier Series. This time we make use of a couple nice integration tricks involving whether sin and cos are even functions (which means $f(-x)=f(x)$) or odd functions (which means $f(-x)=-f(x)$). 
+\end{video}
+
 
 You may have noticed by now that an odd function has no cosine terms in the 
 Fourier series and an even function has no sine terms in the Fourier series.
@@ -2659,8 +2597,6 @@ $\frac{t}{\pi} + \sum\limits_{n=1}^\infty \frac{1}{2^n(\pi-n^2)} \sin(nt)$
 \section{Applications of Fourier series}
 \label{appoffourier:section}
 
-\sectionnotes{2 lectures\EPref{, \S9.4 in \cite{EP}}\BDref{,
-not in \cite{BD}}}
 
 \subsection{Periodically forced oscillation}
 
@@ -3109,8 +3045,7 @@ $x =
 \section{PDEs, separation of variables, and the heat equation}
 \label{heateq:section}
 
-\sectionnotes{2 lectures\EPref{, \S9.5 in \cite{EP}}\BDref{,
-\S10.5 in \cite{BD}}}
+
 
 Let us recall that a \emph{\myindex{partial differential equation}} or
 \emph{\myindex{PDE}} is an equation containing the partial derivatives
@@ -3855,8 +3790,7 @@ a) $0$,
 \sectionnewpage
 \section{One-dimensional wave equation} \label{we:section}
 
-\sectionnotes{1 lecture\EPref{, \S9.6 in \cite{EP}}\BDref{,
-\S10.7 in \cite{BD}}}
+
 
 Imagine we have a tensioned guitar string of length $L$.  Let us 
 only consider vibrations in one direction.  Let
@@ -4482,8 +4416,7 @@ $y(x,t) = \sin(2x)+t\sin(x)$
 \section{D'Alembert solution of the wave equation}
 \label{dalemb:section}
 
-\sectionnotes{1 lecture\EPref{, different from \S9.6 in \cite{EP}}\BDref{,
-part of \S10.7 in \cite{BD}}}
+
 
 We have solved the wave equation by using Fourier series.  But it is often
 more convenient to use the so-called
@@ -4995,8 +4928,7 @@ c) $y(3,9) = \nicefrac{1}{2}$
 \section{Steady state temperature and the Laplacian}
 \label{dirich:section}
 
-\sectionnotes{1 lecture\EPref{, \S9.7 in \cite{EP}}\BDref{,
-\S10.8 in \cite{BD}}}
+
 
 Consider an insulated wire, a plate, or a 3-dimensional object.
 We apply
@@ -5474,8 +5406,7 @@ $u(x,y) =
 \section{Dirichlet problem in the circle and the Poisson kernel}
 \label{dirichdisc:section}
 
-\sectionnotes{2 lectures\EPref{, \S9.7 in \cite{EP}}\BDref{,
-\S10.8 in \cite{BD}}}
+
 
 \subsection{Laplace in polar coordinates}
 

--- a/ch-fourier-and-pde.tex
+++ b/ch-fourier-and-pde.tex
@@ -367,10 +367,9 @@ we consider \eqref{bv:eq1} we have $x_1(a) = x_1(b) = x_2(a) = x_2(b) = 0$
 and so $x_2' x_1 - x_2 x_1'$ is zero at both $a$ and $b$.
 As $\lambda_1 \not= \lambda_2$, the theorem follows.
 
-\begin{exercise}[easy]
-Finish the proof of the theorem (check the last equality in the proof) for the cases
+Verify: finish the proof of the theorem (check the last equality in the proof) for the cases
 \eqref{bv:eq2} and \eqref{bv:eq3}.
-\end{exercise}
+
 
 The function $\sin (n t)$ is an eigenfunction for the problem
 $x''+\lambda x = 0$, $x(0) = 0$, $x(\pi) = 0$. 
@@ -569,64 +568,24 @@ for the rope to stay \myquote{popped out}.
 
 \subsection{Exercises}
 
-Hint for the following exercises:  Note that
-when $\lambda > 0$, then
-$\cos \bigl( \sqrt{\lambda}\, (t - a) \bigr)$
-and $\sin  \bigl( \sqrt{\lambda}\, (t - a) \bigr)$
-are also solutions of the homogeneous
-equation.
+%Hint for the following exercises:  Note that
+%when $\lambda > 0$, then
+%$\cos \bigl( \sqrt{\lambda}\, (t - a) \bigr)$
+%and $\sin  \bigl( \sqrt{\lambda}\, (t - a) \bigr)$
+%are also solutions of the homogeneous
+%equation.
 
 \begin{exercise}
-Compute all
-eigenvalues and eigenfunctions of
-$x'' + \lambda x = 0, ~ x(a) = 0, ~ x(b) = 0$ (assume $a < b$).
+	Suppose $x'' + \lambda x = 0$ and $x(0)=1$, $x(1) = 1$.
+	Find all $\lambda$ for which there is more
+	than one solution.  Also find the corresponding solutions (only for the
+	eigenvalues).
 \end{exercise}
-
-\begin{exercise}
-Compute all
-eigenvalues and eigenfunctions of
-$x'' + \lambda x = 0, ~ x'(a) = 0, ~ x'(b) = 0$ (assume $a < b$).
-\end{exercise}
-
-\begin{exercise}
-Compute all
-eigenvalues and eigenfunctions of
-$x'' + \lambda x = 0, ~ x'(a) = 0, ~ x(b) = 0$ (assume $a < b$).
-\end{exercise}
-
-\begin{exercise}
-Compute all 
-eigenvalues and eigenfunctions of
-$x'' + \lambda x = 0, ~ x(a) = x(b), ~ x'(a) = x'(b)$ (assume $a < b$).
-\end{exercise}
-
-\begin{exercise}
-We skipped the case of $\lambda < 0$ for
-the boundary value problem
-$x'' + \lambda x = 0, ~ x(-\pi) = x(\pi), ~ x'(-\pi) = x'(\pi)$.
-Finish the calculation and show that there are no negative eigenvalues.
-\end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Consider a spinning string of length 2 and linear density 0.1 and tension 3.
-Find smallest angular velocity when the string pops out.
-\end{exercise}
-\exsol{%
-$\omega = \pi \sqrt{\frac{15}{2}}$
-}
-
-\begin{exercise}
-Suppose $x'' + \lambda x = 0$ and $x(0)=1$, $x(1) = 1$.
-Find all $\lambda$ for which there is more
-than one solution.  Also find the corresponding solutions (only for the
-eigenvalues).
-\end{exercise}
-\exsol{%
-$\lambda_k = 4 k^2 \pi^2$ for $k = 1,2,3,\ldots$
-\quad
-$x_k =  \cos (2k\pi t) + B \sin (2k\pi t)$ \quad (for any $B$)
+\exsolution{%
+	Solving $x''+\lambda x=0$, the general solution will depend on whether $\lambda>0$, $\lambda =0$, or $\lambda <0$. Considering the case $\lambda>0$, we get two complex roots to the auxiliary equation and hence the general solution will be $x(t)=A\cos(\sqrt{\lambda}t)+B\sin(\sqrt{\lambda}t)$. Applying the given boundary conditions, we get
+	$\lambda_k = 4 k^2 \pi^2$ for $k = 1,2,3,\ldots$
+	\quad
+	$x_k =  \cos (2k\pi t) + B \sin (2k\pi t)$ \quad (for any $B$). Also, $\lambda>0$ is the only case for which we get more than one solution.
 }
 
 \begin{exercise}
@@ -650,18 +609,89 @@ the solution is always identically zero.  One condition is always
 enough to guarantee a unique solution for a first order equation.
 }
 
-\begin{exercise}[challenging]
-Suppose $x''' + \lambda x = 0$ and $x(0)=0$, $x'(0) = 0$, $x(1) = 0$.
-Suppose that $\lambda > 0$.  Find an equation that all such
-eigenvalues must satisfy.
-Hint: Note that $-\sqrt[3]{\lambda}$ is a root
-of $r^3+\lambda = 0$.
+\begin{exercise}
+	Solve the second order eigenvalue problem
+	$x' + \lambda x = 0$ and $x(0)=0$, $x'(L) = 0$.
 \end{exercise}
 \exsol{%
-$\frac{\sqrt{3}}{3} e^{\frac{-3}{2}\sqrt[3]{\lambda}}
-- \frac{\sqrt{3}}{3} \cos \bigl( \frac{\sqrt{3}\, \sqrt[3]{\lambda}}{2} \bigr)
-+ \sin \bigl( \frac{\sqrt{3}\, \sqrt[3]{\lambda}}{2}\bigr) = 0$
+	$x(t)=\sin\frac{(2n-1)\pi t}{2L}$
 }
+
+The following exercises won't be covered in Math 204. 
+
+\begin{exercise}
+    Compute all
+    eigenvalues and eigenfunctions of
+    $x'' + \lambda x = 0, ~ x(a) = 0, ~ x(b) = 0$ (assume $a < b$).
+    \end{exercise}
+    
+    \begin{exercise}
+    Compute all
+    eigenvalues and eigenfunctions of
+    $x'' + \lambda x = 0, ~ x'(a) = 0, ~ x'(b) = 0$ (assume $a < b$).
+    \end{exercise}
+    
+    \begin{exercise}
+    Compute all
+    eigenvalues and eigenfunctions of
+    $x'' + \lambda x = 0, ~ x'(a) = 0, ~ x(b) = 0$ (assume $a < b$).
+    \end{exercise}
+    
+    \begin{exercise}
+    Compute all 
+    eigenvalues and eigenfunctions of
+    $x'' + \lambda x = 0, ~ x(a) = x(b), ~ x'(a) = x'(b)$ (assume $a < b$).
+    \end{exercise}
+    
+    \begin{exercise}
+    We skipped the case of $\lambda < 0$ for
+    the boundary value problem
+    $x'' + \lambda x = 0, ~ x(-\pi) = x(\pi), ~ x'(-\pi) = x'(\pi)$.
+    Finish the calculation and show that there are no negative eigenvalues.
+    \end{exercise}
+    
+    \begin{exercise}
+    Consider a spinning string of length 2 and linear density 0.1 and tension 3.
+    Find smallest angular velocity when the string pops out.
+    \end{exercise}
+    \exsol{%
+    $\omega = \pi \sqrt{\frac{15}{2}}$
+    }
+    
+    \begin{exercise}
+    Suppose $x'' + x = 0$ and $x(0)=0$, $x'(\pi) = 1$.
+    Find all the solution(s) if any exist.
+    \end{exercise}
+    \exsol{%
+    $x(t) = - \sin(t)$
+    }
+    
+    \begin{exercise}
+    Consider
+    $x' + \lambda x = 0$ and $x(0)=0$, $x(1) = 0$.  Why does it not
+    have any eigenvalues?  Why does any first order equation with two endpoint
+    conditions such as above have no eigenvalues?
+    \end{exercise}
+    \exsol{%
+    General solution is $x = C e^{-\lambda t}$.  Since $x(0) = 0$ then $C=0$, and so $x(t) = 0$.
+    Therefore,
+    the solution is always identically zero.  One condition is always
+    enough to guarantee a unique solution for a first order equation.
+    }
+    
+    \begin{exercise}[challenging]
+    Suppose $x''' + \lambda x = 0$ and $x(0)=0$, $x'(0) = 0$, $x(1) = 0$.
+    Suppose that $\lambda > 0$.  Find an equation that all such
+    eigenvalues must satisfy.
+    Hint: Note that $-\sqrt[3]{\lambda}$ is a root
+    of $r^3+\lambda = 0$.
+    \end{exercise}
+    \exsol{%
+    $\frac{\sqrt{3}}{3} e^{\frac{-3}{2}\sqrt[3]{\lambda}}
+    - \frac{\sqrt{3}}{3} \cos \bigl( \frac{\sqrt{3}\, \sqrt[3]{\lambda}}{2} \bigr)
+    + \sin \bigl( \frac{\sqrt{3}\, \sqrt[3]{\lambda}}{2}\bigr) = 0$
+    }
+    
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -730,11 +760,10 @@ mistake is to assume that a formula for $f(t)$ holds for its extension.  It
 can be confusing when the formula for $f(t)$ is periodic, but with perhaps
 a different period.
 
-\begin{exercise}
-Define $f(t) = \cos t$ on $[\nicefrac{-\pi}{2},\nicefrac{\pi}{2}]$.  Take the $\pi$-periodic
+Exercise: Define $f(t) = \cos t$ on $[\nicefrac{-\pi}{2},\nicefrac{\pi}{2}]$.  Take the $\pi$-periodic
 extension and sketch its graph.  How does it compare to the graph of
 $\cos t$?
-\end{exercise}
+
 
 
 
@@ -870,9 +899,9 @@ $a_m =
 \frac{\langle \, f(t) \, , \, \cos (mt) \, \rangle}{\langle \, \cos (mt) \, , \,
 \cos (mt) \, \rangle}$.
 
-\begin{exercise}
-Carry out the calculation for $a_0$ and $b_m$.
-\end{exercise}
+
+Exercise: Carry out the calculation for $a_0$ and $b_m$.
+
 
 \begin{example}
 Take the function
@@ -1100,8 +1129,11 @@ terms in the series we take.
 \diffyincludegraphics{width=3in}{width=4.5in}{ts-squarewave-gibbs}
 \caption{Gibbs phenomenon in action.\label{ts:squarewavegibbsfig}}
 \end{myfig}
-
 \medskip
+
+
+
+
 
 We can think of a periodic function as a \myquote{signal} being a superposition of
 many signals of pure frequency.  For example, we could think of the square
@@ -1122,22 +1154,161 @@ simplest way to make sound using a computer is the square wave, and the sound
 is very different from a pure tone.  If you ever played video games
 from the 1980s or so, then you heard what square waves sound like.
 
+
+
 \subsection{Exercises}
+
+\begin{exercise}
+	Suppose $f(t)$ is defined on $[-\pi,\pi]$ as $f(t) = \sin(t)$.  Extend
+	periodically and compute the Fourier series.
+\end{exercise}
+\exsolution{%
+%\includegraphics[scale=0.5]{FourierSeriesQ1.pdf}
+The graph of the periodically extended $f(t)$ is shown in figure. We then calcualte the Fourier coefficients and see that
+\begin{equation*}
+a_{0}=0,\quad a_{n}=0, b_{n}=0\,(n\ne 1)\nonumber
+\end{equation*}
+Calculating $b_{n}$ for $n=1$, we find that $b_{1}=1$. Therefore, the Fourier series for the given $f(t)$ is $\sin(t)$.
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ1}
+\caption{Periodic Extension of $f(t)=\sin t$ on $[-\pi,\pi]$ \label{FourierSeriesQ1fig}}
+\end{myfig}
+\medskip
+}
+
+\begin{exercise}
+	Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $f(t) = \sin(\pi t)$.  Extend
+	periodically and compute the Fourier series.
+\end{exercise}
+\exsol{%
+	$\sum\limits_{n=1}^\infty
+	\frac{(\pi-n) \sin( \pi n+{\pi}^{2})
+		+(\pi+n)\sin(\pi n-{\pi}^{2}) }{\pi {n}^{2}-{\pi}^{3}}
+	\sin(nt)$
+	%$a_0 = \frac{1}{\pi} \int_{-\pi}^\pi \sin(\pi t) \, dt$
+	%\\
+	%$a_n =
+	%\frac{1}{\pi} \int_{-\pi}^\pi \sin(\pi t) \cos (nt) \, dt$
+	%\\
+	%$b_n =
+	%\frac{1}{\pi} \int_{-\pi}^\pi f(t) \sin (nt) \, dt$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ2}
+\caption{Periodic Extension of $f(t)=\sin \pi t$ on $(-\pi,\pi]$ \label{FourierSeriesQ2}}
+\end{myfig}
+\medskip
+}
+
+\begin{exercise}
+	Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $f(t) = \sin^2(t)$.
+	Extend
+	periodically and compute the Fourier series.
+\end{exercise}
+\exsol{%
+	$\frac{1}{2}-\frac{1}{2}\cos(2t)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ3}
+\caption{Periodic Extension of $f(t)=\sin \pi t$ on $(-\pi,\pi]$ \label{FourierSeriesQ3}}
+\end{myfig}
+\medskip
+}
+
+
+\begin{exercise}
+	Suppose $f(t)$ is defined on $[-\pi,\pi]$ as $t^2$.
+	Extend periodically and compute the Fourier series of $f(t)$.
+\end{exercise}
+\exsol{%
+	$\frac{\pi^{2}}{3} + \sum\limits_{n=1}^\infty
+	\frac{4(-1)^{n}}{{n}^{2}}
+	\cos(nt)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ4}
+\caption{Periodic Extension of $f(t)=t^{2}$ on $[-\pi,\pi]$ \label{FourierSeriesQ4}}
+\end{myfig}
+	\medskip
+}
+
+
+\begin{exercise}
+	Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $t^3$.
+	Extend periodically and compute the Fourier series of $f(t)$.
+\end{exercise}
+\exsol{%
+	$\sum\limits_{n=1}^\infty
+	\frac{2(-1)^{n}(6-n^{2}\pi^{2})}{{n}^{3}}
+	\sin(nt)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ5}
+\caption{Periodic Extension of $f(t)=t^{3}$ on $(-\pi,\pi]$ \label{FourierSeriesQ5}}
+\end{myfig}
+	\medskip
+}
+
+
+\begin{exercise}
+	Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $t^4$.
+	Extend periodically and compute the Fourier series.
+\end{exercise}
+\exsol{%
+	$\frac{\pi^4}{5} + \sum\limits_{n=1}^\infty
+	\frac{{(-1)}^{n} (8{\pi}^{2}{n}^{2}-48) }{{n}^{4}}
+	\cos(nt)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ6}
+\caption{Periodic Extension of $f(t)=t^{4}$ on $(-\pi,\pi]$ \label{FourierSeriesQ6}}
+\end{myfig}
+	\medskip
+}
 
 \begin{exercise}
 Suppose $f(t)$ is defined on $[-\pi,\pi]$ as $\sin (5t) + \cos (3t)$.  Extend
 periodically and compute the Fourier series of $f(t)$.
 \end{exercise}
+\exsol{%
+	$\cos (3t) + \sin (5t)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ7}
+\caption{Periodic Extension of $f(t)=\sin (5t) + \cos (3t)$ on $(-\pi,\pi]$ \label{FourierSeriesQ7}}
+\end{myfig}
+	\medskip
+}
 
 \begin{exercise}
 Suppose $f(t)$ is defined on $[-\pi,\pi]$ as $\lvert t \rvert$.
 Extend periodically and compute the Fourier series of $f(t)$.
 \end{exercise}
+\exsol{%
+$\frac{\pi}{2}+\sum\limits_{n=1}^\infty\frac{2(-1+(-1)^{n})}{n^{2}\pi}\cos(nt)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ8}
+\caption{Periodic Extension of $f(t)=\lvert t \rvert$ on $[-\pi,\pi]$ \label{FourierSeriesQ8}}
+\end{myfig}
+\medskip
+}
 
 \begin{exercise}
 Suppose $f(t)$ is defined on $[-\pi,\pi]$ as $\lvert t \rvert^3$.
 Extend periodically and compute the Fourier series of $f(t)$.
 \end{exercise}
+\exsol{%
+	$\frac{\pi^{3}}{4}+\sum\limits_{n=1}^\infty\frac{12(1-(-1)^{n})+6n^{2}\pi^{2}(-1)^{n}}{n^{4}\pi}\cos(nt)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ9}
+\caption{Periodic Extension of $f(t)=\lvert t \rvert^3$ on $[-\pi,\pi]$ \label{FourierSeriesQ9}}
+\end{myfig}
+	\medskip
+}
+
 
 \begin{exercise}
 Suppose $f(t)$ is defined on $(-\pi,\pi]$ as
@@ -1150,16 +1321,15 @@ f(t) =
 \end{equation*}
 Extend periodically and compute the Fourier series of $f(t)$.
 \end{exercise}
-
-\begin{exercise}
-Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $t^3$.
-Extend periodically and compute the Fourier series of $f(t)$.
-\end{exercise}
-
-\begin{exercise}
-Suppose $f(t)$ is defined on $[-\pi,\pi]$ as $t^2$.
-Extend periodically and compute the Fourier series of $f(t)$.
-\end{exercise}
+\exsol{%
+	$\sum\limits_{n=1}^\infty\frac{2(1-(-1)^{n})}{n\pi}\sin(nt)$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ10}
+\caption{Periodic Extension of $f(t)$ on $(-\pi,\pi]$ \label{FourierSeriesQ10}}
+\end{myfig}
+	\medskip
+}
 
 There is another form of the Fourier series using complex exponentials
 $e^{nt}$ for $n=\ldots,-2,-1,0,1,2,\ldots$ instead of
@@ -1191,52 +1361,7 @@ c_0 + \sum_{m=1}^\infty \Bigl( c_m e^{imt} + c_{-m} e^{-imt}  \Bigr).
 \end{samepage}
 \end{exercise}
 
-\setcounter{exercise}{100}
 
-\begin{exercise}
-Suppose $f(t)$ is defined on $[-\pi,\pi]$ as $f(t) = \sin(t)$.  Extend
-periodically and compute the Fourier series.
-\end{exercise}
-\exsol{%
-$\sin(t)$
-}
-
-\begin{exercise}
-Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $f(t) = \sin(\pi t)$.  Extend
-periodically and compute the Fourier series.
-\end{exercise}
-\exsol{%
-$\sum\limits_{n=1}^\infty
-\frac{(\pi-n) \sin( \pi n+{\pi}^{2})
-+(\pi+n)\sin(\pi n-{\pi}^{2}) }{\pi {n}^{2}-{\pi}^{3}}
-\sin(nt)$
-%$a_0 = \frac{1}{\pi} \int_{-\pi}^\pi \sin(\pi t) \, dt$
-%\\
-%$a_n =
-%\frac{1}{\pi} \int_{-\pi}^\pi \sin(\pi t) \cos (nt) \, dt$
-%\\
-%$b_n =
-%\frac{1}{\pi} \int_{-\pi}^\pi f(t) \sin (nt) \, dt$
-}
-
-\begin{exercise}
-Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $f(t) = \sin^2(t)$.
-Extend
-periodically and compute the Fourier series.
-\end{exercise}
-\exsol{%
-$\frac{1}{2}-\frac{1}{2}\cos(2t)$
-}
-
-\begin{exercise}
-Suppose $f(t)$ is defined on $(-\pi,\pi]$ as $f(t) = t^4$.
-Extend periodically and compute the Fourier series.
-\end{exercise}
-\exsol{%
-$\frac{\pi^4}{5} + \sum\limits_{n=1}^\infty
-\frac{{(-1)}^{n} (8{\pi}^{2}{n}^{2}-48) }{{n}^{4}}
-\cos(nt)$
-}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1599,9 +1724,8 @@ and extend to a
 This function has one derivative everywhere, but it
 does not have a second derivative whenever $t$ is an integer.
 
-\begin{exercise}
-Compute $f''(0+)$ and $f''(0-)$.
-\end{exercise}
+Exercise: Compute $f''(0+)$ and $f''(0-)$.
+
 
 Let us compute the Fourier series coefficients.  The actual computation
 involves several integration by parts and is left to student.
@@ -1706,13 +1830,70 @@ the series again, we would obtain
 \end{equation*}
 which does not converge!
 
-\begin{exercise}
-Use a computer to plot the series we obtained for $f(t)$, $f'(t)$ and
+Computer Exercise: Use a computer to plot the series we obtained for $f(t)$, $f'(t)$ and
 $f''(t)$.  That is, plot say the first 5 harmonics of the functions.  At what
 points does $f''(t)$ have the discontinuities?
-\end{exercise}
 
 \subsection{Exercises}
+
+\begin{exercise}
+	Let
+	\begin{equation*}
+	f(t) = t^2 \qquad \text{for } \; {-2} < t \leq 2
+	\end{equation*}
+	extended periodically.
+	\begin{tasks}
+		\task Compute the Fourier series for $f(t)$.
+		\task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
+	\end{tasks}
+\end{exercise}
+\exsolution{%
+Using the general Fourier coefficients for a $2L-$periodic function, we can find:
+a) $\frac{8}{6}+\sum\limits_{n=1}^\infty\frac{16{(-1)}^n}{\pi^2 n^2}\cos\bigl(\frac{n\pi}{2} t\bigr)$
+\quad
+b) $\frac{8}{6}-\frac{16}{\pi^2 }
+\cos\bigl(\frac{\pi}{2} t\bigr)+\frac{4}{\pi^2}\cos\bigl(\pi t\bigr)-\frac{16}{9\pi^2}\cos\bigl(\frac{3\pi}{2} t\bigr) + \cdots$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ3}
+\caption{Periodic Extension of $f(t)=t^{2}$ on $(-2,\pi]$ \label{GeneralFourierSeriesQ3}}
+\end{myfig}
+	\medskip
+}
+
+\begin{exercise}
+	Let
+	\begin{equation*}
+	f(t) = t \qquad \text{for } \; {-\lambda} < t \leq \lambda \; \text{ (for some } \lambda > 0 \text{)}
+	\end{equation*}
+	extended periodically.
+	\begin{tasks}
+		\task Compute the Fourier series for $f(t)$.
+		\task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
+	\end{tasks}
+\end{exercise}
+\exsol{%
+	a)
+	$\sum\limits_{n=1}^\infty
+	\frac{{(-1)}^{n+1}2\lambda}{n \pi}
+	\sin\bigl(\frac{n\pi}{\lambda} t\bigr)$
+	\quad
+	b)
+	$\frac{2\lambda}{\pi}
+	\sin\bigl(\frac{\pi}{\lambda} t\bigr)
+	-
+	\frac{\lambda}{\pi}
+	\sin\bigl(\frac{2\pi}{\lambda} t\bigr)
+	+
+	\frac{2\lambda}{3\pi}
+	\sin\bigl(\frac{3\pi}{\lambda} t\bigr) - \cdots$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ4}
+\caption{Periodic Extension of $f(t)=t$ on $(-\lambda,\lambda]$ \label{GeneralFourierSeriesQ4}}
+\end{myfig}
+	\medskip
+}
 
 \begin{exercise}
 Let
@@ -1729,6 +1910,19 @@ extended periodically.
 \task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
 \end{tasks}
 \end{exercise}
+\exsol{%
+	a)
+	$\frac{1}{4}+\sum\limits_{n=1}^\infty
+	\frac{-1+(-1)^{n}}{n^{2} \pi^{2}}\cos(n\pi t)+\frac{(-1)^{n+1}}{n \pi}\sin(n\pi t)$
+	\quad
+	b) Expand the above series for $n=1$ to $n=3$.
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ5}
+\caption{Periodic Extension of $f(t)$ on $(-1,1]$ \label{GeneralFourierSeriesQ5}}
+\end{myfig}
+	\medskip
+}
 
 \begin{exercise}
 Let
@@ -1745,6 +1939,20 @@ extended periodically.
 \task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
 \end{tasks}
 \end{exercise}
+\exsol{%
+	a)
+	$\frac{5}{12}+\sum\limits_{n=1}^\infty
+	\frac{-1+3(-1)^{n}}{n^{2} \pi^{2}}\cos(n\pi t)+\frac{2(-1+(-1)^{n})}{n^{3} \pi^{3}}\sin(n\pi t)$
+	\quad
+	b) Expand the above series for $n=1$ to $n=3$.
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ6}
+\caption{Periodic Extension of $f(t)$ on $(-1,1]$ \label{GeneralFourierSeriesQ6}}
+\end{myfig}
+	\medskip
+}
+
 
 \begin{exercise}
 Let
@@ -1761,19 +1969,20 @@ extended periodically (period is 20).
 \task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
 \end{tasks}
 \end{exercise}
+\exsol{%
+	a)
+	$\frac{1}{2}+\sum\limits_{n=1}^\infty
+	\frac{2(-1+(-1)^{n})}{n^{2} \pi^{2}}\cos(\frac{n\pi}{10} t)$
+	\quad
+	b) Expand the above series for $n=1$ to $n=3$.
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ7}
+\caption{Periodic Extension of $f(t)=t$ on $(-10,10]$ \label{GeneralFourierSeriesQ7}}
+\end{myfig}
+	\medskip
+}
 
-\begin{exercise}
-Let $f(t) = \sum_{n=1}^\infty \frac{1}{n^3} \cos (n t)$.  Is $f(t)$
-continuous and differentiable everywhere?  Find the derivative (if it exists
-everywhere)
-or justify why $f(t)$ is not differentiable everywhere.
-\end{exercise}
-
-\begin{exercise}
-Let $f(t) = \sum_{n=1}^\infty \frac{{(-1)}^n}{n} \sin (n t)$.  Is $f(t)$
-differentiable everywhere?  Find the derivative (if it exists everywhere) or
-justify why $f(t)$ is not differentiable everywhere.
-\end{exercise}
 
 \begin{exercise}
 Let
@@ -1791,6 +2000,20 @@ extended periodically.
 \task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
 \end{tasks}
 \end{exercise}
+\exsol{%
+	a)
+	$\frac{1}{4}+\sum\limits_{n=1}^\infty
+	\frac{-2(1+(-1)^{n}-2\cos(n\pi/2))}{n^{2} \pi^{2}}\cos(\frac{n\pi}{2} t)+\frac{4\sin(n\pi/2)}{n^{2} \pi^{2}}\sin(\frac{n\pi}{2} t)$
+	\quad
+	b) Expand the above series for $n=1$ to $n=3$.
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ8}
+\caption{Periodic Extension of $f(t)=t$ on $(-2,2]$ \label{GeneralFourierSeriesQ8}}
+\end{myfig}
+	\medskip
+}
+
 
 \begin{exercise}
 Let
@@ -1804,6 +2027,92 @@ extended periodically.
 \task What does the series converge to at $t=1$.
 \end{tasks}
 \end{exercise}
+\exsol{%
+a)
+$\frac{e^{2}-1}{2e}+\sum\limits_{n=1}^\infty \frac{(-1)^{n}(e^{2}-1)}{e(1+n^{2}\pi^{2})}\cos(n\pi t)+\frac{(-1)^{n+1}(n\pi)(e^{2}-1)}{e(1+n^{2}\pi^{2})}\sin(n\pi t)$
+\quad
+b)
+$\frac{e^{2}-1}{2e} + \frac{-(e^{2}-1)}{e(1+\pi^{2})}\cos(\pi t)+\frac{(\pi)(e^{2}-1)}{e(1+\pi^{2})}\sin(\pi t)
++
+\frac{(e^{2}-1)}{e(1+4\pi^{2})}\cos(2\pi t)+\frac{(-2\pi)(e^{2}-1)}{e(1+4\pi^{2})}\sin(2\pi t)
++
+\frac{-(e^{2}-1)}{e(1+9\pi^{2})}\cos(3\pi t)+\frac{(3\pi)(e^{2}-1)}{e(1+9\pi^{2})}\sin(3\pi t) + \cdots$
+\quad
+c) $\frac{e+e^{-1}}{2}$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ9}
+\caption{Periodic Extension of $f(t)=e^{t}$ on $(-1,1]$ \label{GeneralFourierSeriesQ9}}
+\end{myfig}
+	\medskip
+}
+
+\begin{exercise}
+	Let
+	\begin{equation*}
+	f(t) = 
+	\begin{cases}
+	0 & \text{if } \; {-2} < t \leq 0, \\
+	2 & \text{if } \; \phantom{-}0 < t \leq 2,
+	\end{cases}
+	\end{equation*}
+	extended periodically.  Suppose $F(t)$ is the function given
+	by the Fourier series of $f$.  Without computing the Fourier series
+	evaluate
+	\begin{tasks}(3)
+		\task $F(0)$
+		\task $F(-1)$
+		\task $F(1)$
+		\task $F(-2)$
+		\task $F(4)$
+		\task $F(-9)$
+	\end{tasks}
+\end{exercise}
+\exsol{%
+	a) $F(0) = 1$, 
+	b) $F(-1) = 0$, 
+	c) $F(1) = 2$, 
+	d) $F(-2) = 1$, 
+	e) $F(4) = 1$, 
+	f) $F(-9) = 0$ 
+}
+
+\begin{exercise}
+	Let
+	\begin{equation*}
+	f(t) = \nicefrac{t}{2} \qquad \text{for } \; {-\pi} < t < \pi
+	\end{equation*}
+	extended periodically.
+	\begin{tasks}
+		\task Compute the Fourier series for $f(t)$.
+		\task Plug in $t=\nicefrac{\pi}{2}$ to find a series representation
+		for $\nicefrac{\pi}{4}$.
+		\task Using the first 4 terms of the result from part b) approximate
+		$\nicefrac{\pi}{4}$.
+	\end{tasks}
+\end{exercise}
+\exsolution{%
+	a)
+	$\sum\limits_{n=1}^\infty
+	\frac{{(-1)}^{n+1}}{n} \sin(nt)$
+	\qquad
+	b) $f$ is continuous at $t=\nicefrac{\pi}{2}$ so the
+	Fourier series converges to $f(\nicefrac{\pi}{2}) = \nicefrac{\pi}{4}$.
+	Obtain (for even $n$, we get zero)
+	$\nicefrac{\pi}{4} = \sum\limits_{n=1}^\infty
+	\frac{{(-1)}^{n+1}}{2n-1} = 1 - \nicefrac{1}{3} + \nicefrac{1}{5}-
+	\nicefrac{1}{7} + \cdots$.
+	\qquad
+	c) Using the first 4 terms get $\nicefrac{76}{105}\approx 0.72$ (quite a bad
+	approximation, you would have to take about 50 terms to start to get to
+	within $0.01$ of $\nicefrac{\pi}{4}$).
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ11}
+\caption{Periodic Extension of $f(t)=t/2$ on $(-\pi,\pi)$ \label{GeneralFourierSeriesQ11}}
+\end{myfig}
+	\medskip
+}
 
 \begin{exercise}
 Let
@@ -1820,6 +2129,28 @@ evaluate $\displaystyle \sum_{n=1}^\infty \frac{{(-1)}^n}{n^2} = 1 - \frac{1}{4}
 \frac{1}{9} + \cdots$.
 \end{tasks}
 \end{exercise}
+\exsolution{%
+	a)
+	$\frac{2}{6}+\sum\limits_{n=1}^\infty
+	\frac{{4(-1)}^{n}}{n^{2}\pi^{2}} \cos(n\pi t)$
+	\qquad
+	b) $f$ is continuous at $t=0$ so the
+	Fourier series converges to $f(0) = 0$.
+	Obtain 
+	$0 = \frac{1}{3}+\frac{4}{\pi^{2}}\sum\limits_{n=1}^\infty
+	\frac{{(-1)}^{n}}{n^{2}}$. This gives $\sum\limits_{n=1}^\infty\frac{{(-1)}^{n}}{n^{2}}=-\frac{\pi^{2}}{12}$
+	\qquad
+	c) Using $t=1$, we obtain 
+	$1 = \frac{1}{3}+\frac{4}{\pi^{2}}\sum\limits_{n=1}^\infty
+	\frac{{(-1)}^{n}}{n^{2}}\cos(n\pi)$. This gives $\sum\limits_{n=1}^\infty\frac{1}{n^{2}}=\frac{\pi^{2}}{6}$
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{GeneralFourierSeriesQ12}
+\caption{Periodic Extension of $f(t)=t^{2}$ on $(-1,1]$ \label{GeneralFourierSeriesQ12}}
+\end{myfig}
+	\medskip
+}
+
 
 \begin{exercise}
 Let
@@ -1842,65 +2173,23 @@ evaluate
 \task $F(-9)$
 \end{tasks}
 \end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Let
-\begin{equation*}
-f(t) = t^2 \qquad \text{for } \; {-2} < t \leq 2
-\end{equation*}
-extended periodically.
-\begin{tasks}
-\task Compute the Fourier series for $f(t)$.
-\task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
-\end{tasks}
-\end{exercise}
 \exsol{%
-a) $\frac{8}{6} +
-\sum\limits_{n=1}^\infty
-\frac{16{(-1)}^n}{\pi^2 n^2}
-\cos\bigl(\frac{n\pi}{2} t\bigr)$
-\quad
-b) $\frac{8}{6}
--
-\frac{16}{\pi^2 }
-\cos\bigl(\frac{\pi}{2} t\bigr)
-+
-\frac{4}{\pi^2}
-\cos\bigl(\pi t\bigr)
--
-\frac{16}{9\pi^2}
-\cos\bigl(\frac{3\pi}{2} t\bigr) + \cdots$
+	a) $F(2) = 2$, 
+	b) $F(-2) = 0$, 
+	c) $F(4) = 0$, 
+	d) $F(-4) = 2$, 
+	e) $F(3) = 3/2$, 
+	f) $F(-9) = 3/2$ 
+\begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSeriesQ13}
+\caption{Periodic Extension of $f(t)=$ on $(-\pi,\pi]$ \label{FourierSeriesQ13}}
+\end{myfig}
+\medskip
 }
 
-\begin{exercise}
-Let
-\begin{equation*}
-f(t) = t \qquad \text{for } \; {-\lambda} < t \leq \lambda \; \text{ (for some } \lambda > 0 \text{)}
-\end{equation*}
-extended periodically.
-\begin{tasks}
-\task Compute the Fourier series for $f(t)$.
-\task Write out the series explicitly up to the $3^{\text{rd}}$ harmonic.
-\end{tasks}
-\end{exercise}
-\exsol{%
-a)
-$\sum\limits_{n=1}^\infty
-\frac{{(-1)}^{n+1}2\lambda}{n \pi}
-\sin\bigl(\frac{n\pi}{\lambda} t\bigr)$
-\quad
-b)
-$\frac{2\lambda}{\pi}
-\sin\bigl(\frac{\pi}{\lambda} t\bigr)
--
-\frac{\lambda}{\pi}
-\sin\bigl(\frac{2\pi}{\lambda} t\bigr)
-+
-\frac{2\lambda}{3\pi}
-\sin\bigl(\frac{3\pi}{\lambda} t\bigr) - \cdots$
-}
+%\setcounter{exercise}{100}
+
 
 \begin{exercise}
 Let
@@ -1911,7 +2200,8 @@ f(t) = \frac{1}{2} + \sum_{n=1}^\infty
 \end{equation*}
 Compute $f'(t)$.
 \end{exercise}
-\exsol{%
+\exsolution{%
+Using term-by-term differentiation, we get
 $f'(t) = \sum\limits_{n=1}^\infty
 \frac{\pi}{n^2+1}
 \cos(n\pi t)$
@@ -1939,65 +2229,19 @@ b) no
 }
 
 \begin{exercise}
-Let
-\begin{equation*}
-f(t) = \nicefrac{t}{2} \qquad \text{for } \; {-\pi} < t < \pi
-\end{equation*}
-extended periodically.
-\begin{tasks}
-\task Compute the Fourier series for $f(t)$.
-\task Plug in $t=\nicefrac{\pi}{2}$ to find a series representation
-for $\nicefrac{\pi}{4}$.
-\task Using the first 4 terms of the result from part b) approximate
-$\nicefrac{\pi}{4}$.
-\end{tasks}
+	Let $f(t) = \sum_{n=1}^\infty \frac{1}{n^3} \cos (n t)$.  Is $f(t)$
+	continuous and differentiable everywhere?  Find the derivative (if it exists
+	everywhere)
+	or justify why $f(t)$ is not differentiable everywhere.
 \end{exercise}
-\exsol{%
-a)
-$\sum\limits_{n=1}^\infty
-\frac{{(-1)}^{n+1}}{n} \sin(nt)$
-\qquad
-b) $f$ is continuous at $t=\nicefrac{\pi}{2}$ so the
-Fourier series converges to $f(\nicefrac{\pi}{2}) = \nicefrac{\pi}{4}$.
-Obtain
-$\nicefrac{\pi}{4} = \sum\limits_{n=1}^\infty
-\frac{{(-1)}^{n+1}}{2n-1} = 1 - \nicefrac{1}{3} + \nicefrac{1}{5}-
-\nicefrac{1}{7} + \cdots$.
-\qquad
-c) Using the first 4 terms get $\nicefrac{76}{105}\approx 0.72$ (quite a bad
-approximation, you would have to take about 50 terms to start to get to
-within $0.01$ of $\nicefrac{\pi}{4}$).
-}
 
 \begin{exercise}
-Let
-\begin{equation*}
-f(t) = 
-\begin{cases}
-0 & \text{if } \; {-2} < t \leq 0, \\
-2 & \text{if } \; \phantom{-}0 < t \leq 2,
-\end{cases}
-\end{equation*}
-extended periodically.  Suppose $F(t)$ is the function given
-by the Fourier series of $f$.  Without computing the Fourier series
-evaluate
-\begin{tasks}(3)
-\task $F(0)$
-\task $F(-1)$
-\task $F(1)$
-\task $F(-2)$
-\task $F(4)$
-\task $F(-8)$
-\end{tasks}
+	Let $f(t) = \sum_{n=1}^\infty \frac{{(-1)}^n}{n} \sin (n t)$.  Is $f(t)$
+	differentiable everywhere?  Find the derivative (if it exists everywhere) or
+	justify why $f(t)$ is not differentiable everywhere.
 \end{exercise}
-\exsol{%
-a) $F(0) = 1$, 
-b) $F(-1) = 0$, 
-c) $F(1) = 2$, 
-d) $F(-2) = 1$, 
-e) $F(4) = 1$, 
-f) $F(-9) = 0$ 
-}
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -2024,15 +2268,14 @@ Recall that a function $f(t)$ is \emph{odd}\index{odd function} if $f(-t) =
 $f(-t) = f(t)$.  For example, $\cos (n t)$ is even and $\sin (n t)$ is odd.
 Similarly the function $t^k$ is even if $k$ is even and odd when $k$ is odd.
 
-\begin{exercise}
-Take two functions $f(t)$ and $g(t)$ and define their product $h(t) =
+Exercise: Take two functions $f(t)$ and $g(t)$ and define their product $h(t) =
 f(t)g(t)$.
 \begin{tasks}
 \task Suppose both $f(t)$ and $g(t)$ are odd.  Is $h(t)$ odd or even?
 \task Suppose one is even and one is odd.  Is $h(t)$ odd or even?
 \task Suppose both are even.  Is $h(t)$ odd or even?
 \end{tasks}
-\end{exercise}
+
 
 If $f(t)$ and $g(t)$ are both odd, then $f(t)+g(t)$ is odd.  Similarly for
 even functions.  On the other hand,
@@ -2074,11 +2317,9 @@ $F_{\text{even}}(t)$ is called the
 \emph{\myindex{even periodic extension}} of $f(t)$.
 For the odd extension we generally assume that $f(0) = f(L) = 0$.
 
-\begin{exercise}
-Check that $F_{\text{odd}}(t)$ is odd and $F_{\text{even}}(t)$ is even.
+Verify: Check that $F_{\text{odd}}(t)$ is odd and $F_{\text{even}}(t)$ is even.
 For $F_{\text{odd}}$,
 assume $f(0) = f(L) = 0$.
-\end{exercise}
 
 \begin{example}
 Take the function $f(t) = t\,(1-t)$ defined on $[0,1]$. 
@@ -2256,8 +2497,7 @@ Explicitly, the first few terms of the series are
 \end{equation*}
 \end{example}
 
-\begin{exercise}
-\leavevmode
+Exercise: 
 \begin{tasks}
 \task Compute the derivative of the even periodic extension of $f(t)$ above and verify it
 has jump discontinuities.  Use the actual definition of $f(t)$, not its cosine
@@ -2265,7 +2505,7 @@ series!
 \task Why is it that the derivative of the even periodic extension of $f(t)$ is the
 odd periodic extension of $f'(t)$?
 \end{tasks}
-\end{exercise}
+
 
 \subsection{Application}
 
@@ -2451,12 +2691,86 @@ x(t) =
 \subsection{Exercises}
 
 \begin{exercise}
+	Let $f(t) = \nicefrac{t}{3}$ on $0 \leq t < 3$.
+	\begin{tasks}
+		\task Find the Fourier series of the even periodic extension.
+		\task Find the Fourier series of the odd periodic extension.
+	\end{tasks}
+\end{exercise}
+\exsol{%
+	a)
+	$\nicefrac{1}{2}
+	+
+	\sum\limits_{\substack{n=1\\n\text{ odd}}}^\infty
+	\frac{-4}{\pi^2 n^2}
+	\cos\bigl(\frac{n\pi}{3} t \bigr)$
+	\qquad
+	b) 
+	$\sum\limits_{n=1}^\infty
+	\frac{2{(-1)}^{n+1}}{\pi n}
+	\sin\bigl(\frac{n\pi}{3} t \bigr)$
+}
+
+\begin{exercise}
+	Let $f(t) = \cos(2t)$ on $0 \leq t < \pi$.
+	\begin{tasks}
+		\task Find the Fourier series of the even periodic extension.
+		\task Find the Fourier series of the odd periodic extension.
+	\end{tasks}
+\end{exercise}
+\exsol{%
+	a)
+	$\cos(2t)$
+	\qquad
+	b) 
+	$\sum\limits_{\substack{n=1 \\n \text{ odd}}}^\infty
+	\frac{-4n}{\pi n^2 - 4 \pi}
+	\sin(n t)$
+}
+
+\begin{exercise}
 Take $f(t) = {(t-1)}^2$ defined on $0 \leq t \leq 1$.
 \begin{tasks}
 \task Sketch the plot of the even periodic extension of $f$.
 \task Sketch the plot of the odd periodic extension of $f$.
 \end{tasks}
 \end{exercise}
+\exsol{%
+a) \begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ6a}
+\caption{Even Periodic Extension of $f(t)=(t-1)^{2}$ on $[0,1]$ \label{FourierSineCosineSeriesQ6a}}
+\end{myfig}
+\medskip
+b) \begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ6b}
+\caption{Odd Periodic Extension of $f(t)=(t-1)^{2}$ on $[0,1]$ \label{FourierSineCosineSeriesQ6b}}
+\end{myfig}
+\medskip
+}
+
+\begin{exercise}
+Take $f(t) = \sin t$ defined on $0 \leq t \leq \pi$.
+\begin{tasks}
+\task Sketch the plot of the even periodic extension of $f$.
+\task Sketch the plot of the odd periodic extension of $f$.
+\end{tasks}
+\end{exercise}
+\exsol{%
+a) \begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ7a}
+\caption{Even Periodic Extension of $f(t)=\sin t$ on $[0,\pi]$ \label{FourierSineCosineSeriesQ7a}}
+\end{myfig}
+\medskip
+b) \begin{myfig}
+\capstart
+\diffyincludegraphics{width=3in}{width=4.5in}{FourierSineCosineSeriesQ7b}
+\caption{Odd Periodic Extension of $f(t)=\sin t$ on $[0,\pi]$ \label{FourierSineCosineSeriesQ7b}}
+\end{myfig}
+\medskip
+}
 
 \begin{exercise}
 Find the Fourier series of both the odd and even
@@ -2465,16 +2779,55 @@ the function $f(t) = {(t-1)}^2$ for $0 \leq t \leq 1$.
 Can you tell which extension is continuous from the Fourier series
 coefficients?
 \end{exercise}
+\exsol{%
+	a) $\sum\limits_{n=1}^{\infty}
+	\frac{-4+4(-1)^{n}+2n^{2}\pi^{2}}{n^{3}\pi^{3}}
+	\sin(n\pi t)$
+	b) $\frac{1}{3}+\sum\limits_{n=1}^{\infty}\frac{4}{n^{2}\pi^{2}}\cos(n\pi t)$
+}
+
 
 \begin{exercise}
 Find the Fourier series of both the odd and even periodic extension of 
 the function $f(t) = t$ for $0 \leq t \leq \pi$.
 \end{exercise}
+\exsol{%
+	a) $\sum\limits_{n=1}^{\infty}
+	\frac{2(-1)^{n+1}}{n}
+	\sin(nt)$
+	b) $\frac{\pi}{2}+\sum\limits_{n=1}^{\infty}\frac{-2+2(-1)^{n}}{n^{2}\pi}\cos(nt)$
+}
+
 
 \begin{exercise}
 Find the Fourier series of the even periodic extension of 
 the function $f(t) = \sin t$ for $0 \leq t \leq \pi$.
 \end{exercise}
+\exsol{%
+	a) $\sin(t)$
+	b) $\frac{2}{\pi}+\sum\limits_{n=2}^{\infty}\frac{2+2(-1)^{n}}{\pi(1-n^{2})}\cos(nt)$
+}
+
+
+\begin{exercise}
+	Let $f(t) = \sum_{n=1}^\infty \frac{1}{n^2} \sin(nt)$.  Solve
+	$x''- x = f(t)$ for the Dirichlet conditions $x(0) = 0$
+	and $x(\pi) = 0$.
+\end{exercise}
+\exsolution{%
+	Since our function $f(t)$ is expanded as a Sine series, we choose $x(t)=\sum\limits_{n=1}^\infty b_{n}\sin(nt)$ [satisfies the given boundary conditions as well]. Using this in the given differential equation, we can find the expression for $b_{n}$ for all $n$. This leaves us with the final solution $\sum\limits_{n=1}^\infty \frac{-1}{n^2(1+n^2)} \sin(nt)$
+}
+
+\begin{exercise}[challenging]
+	Let $f(t) = t + \sum_{n=1}^\infty \frac{1}{2^n} \sin(nt)$.  Solve
+	$x'' + \pi x = f(t)$ for the Dirichlet conditions $x(0) = 0$
+	and $x(\pi) = 1$.  Hint:  Note that $\frac{t}{\pi}$ satisfies the
+	given Dirichlet conditions.
+\end{exercise}
+\exsol{%
+	$\frac{t}{\pi} + \sum\limits_{n=1}^\infty \frac{1}{2^n(\pi-n^2)} \sin(nt)$
+}
+
 
 \begin{exercise}
 \pagebreak[2]
@@ -2488,6 +2841,10 @@ where $f(t) = 1$ on $0 < t < 1$.
 \task Solve for the Neumann conditions $x'(0)=0, x'(1) = 0$.
 \end{tasks}
 \end{exercise}
+\exsolution{First we use even and odd extensions of the given function $f(t)$ to write the Cosine and Sine series, respectively. The Cosine series is given by $1$ and the Sine series is given by $\sum\limits_{n=1,n\,odd}^{\infty}\frac{4}{n\pi}\sin(n\pi t)$.
+	a) Taking $x(t)=\sum\limits_{n=1,n\,odd}^{\infty}b_{n}\sin(n\pi t)$. Using it in the given differential equation, we can find $b_{n}$ to then show that $x(t)=\sum\limits_{n=1,n\,odd}^{\infty}\frac{4}{n\pi(4-n^{2}\pi^{2})}\sin(n\pi t)$
+	b) $x(t)=1/4$ is the required solution.
+}
 
 \begin{exercise}
 Consider
@@ -2500,6 +2857,11 @@ for $f(t) = \sin (2\pi t)$ on $0 < t < 1$.
 \task Solve for the Neumann conditions $x'(0)=0, x'(1) = 0$.
 \end{tasks}
 \end{exercise}
+\exsolution{%
+	a) $x(t)=\frac{1}{9-4\pi^{2}}\sin(2\pi t)$
+	b) $x(t)=\sum\limits_{n=1,n\,odd}^{\infty}\frac{-8}{\pi(9-n^{2}\pi^{2})(n^{2}-4)}\cos(n\pi t)$
+}
+
 
 \begin{exercise}
 Consider
@@ -2509,6 +2871,9 @@ x''(t) + 3 x(t) = f(t) , \quad x(0) = 0, \quad x(1) = 0,
 where $f(t) = \sum_{n=1}^\infty b_n \sin (n \pi t)$.  Write the solution $x(t)$
 as a Fourier series, where the coefficients are given in terms of $b_n$.
 \end{exercise}
+\exsolution{%
+$x(t)=\sum\limits_{n=1}^{\infty}\frac{b_n}{(3-n^{2}\pi^{2})}\sin(n\pi t)$
+}
 
 \begin{exercise}
 Let $f(t) = t^2(2-t)$ for $0 \leq t \leq 2$.  Let $F(t)$ be the odd periodic
@@ -2516,45 +2881,7 @@ extension.  Compute $F(1)$, $F(2)$, $F(3)$, $F(-1)$, $F(\nicefrac{9}{2})$,
 $F(101)$, $F(103)$.  Note: Do \textbf{not} compute using the sine series.
 \end{exercise}
 
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Let $f(t) = \nicefrac{t}{3}$ on $0 \leq t < 3$.
-\begin{tasks}
-\task Find the Fourier series of the even periodic extension.
-\task Find the Fourier series of the odd periodic extension.
-\end{tasks}
-\end{exercise}
-\exsol{%
-a)
-$\nicefrac{1}{2}
-+
-\sum\limits_{\substack{n=1\\n\text{ odd}}}^\infty
-\frac{-4}{\pi^2 n^2}
-\cos\bigl(\frac{n\pi}{3} t \bigr)$
-\qquad
-b) 
-$\sum\limits_{n=1}^\infty
-\frac{2{(-1)}^{n+1}}{\pi n}
-\sin\bigl(\frac{n\pi}{3} t \bigr)$
-}
-
-\begin{exercise}
-Let $f(t) = \cos(2t)$ on $0 \leq t < \pi$.
-\begin{tasks}
-\task Find the Fourier series of the even periodic extension.
-\task Find the Fourier series of the odd periodic extension.
-\end{tasks}
-\end{exercise}
-\exsol{%
-a)
-$\cos(2t)$
-\qquad
-b) 
-$\sum\limits_{\substack{n=1 \\n \text{ odd}}}^\infty
-\frac{-4n}{\pi n^2 - 4 \pi}
-\sin(n t)$
-}
+%\setcounter{exercise}{100}
 
 \begin{exercise}
 Let $f(t)$ be defined on $0 \leq t < 1$.  Now take
@@ -2569,25 +2896,6 @@ $g(t) = \frac{F_{\text{odd}}(t)+ F_{\text{even}}(t)}{2}$.
 a) $f(t)$
 \qquad
 b) $0$
-}
-
-\begin{exercise}
-Let $f(t) = \sum_{n=1}^\infty \frac{1}{n^2} \sin(nt)$.  Solve
-$x''- x = f(t)$ for the Dirichlet conditions $x(0) = 0$
-and $x(\pi) = 0$.
-\end{exercise}
-\exsol{%
-$\sum\limits_{n=1}^\infty \frac{-1}{n^2(1+n^2)} \sin(nt)$
-}
-
-\begin{exercise}[challenging]
-Let $f(t) = t + \sum_{n=1}^\infty \frac{1}{2^n} \sin(nt)$.  Solve
-$x'' + \pi x = f(t)$ for the Dirichlet conditions $x(0) = 0$
-and $x(\pi) = 1$.  Hint:  Note that $\frac{t}{\pi}$ satisfies the
-given Dirichlet conditions.
-\end{exercise}
-\exsol{%
-$\frac{t}{\pi} + \sum\limits_{n=1}^\infty \frac{1}{2^n(\pi-n^2)} \sin(nt)$
 }
 
 
@@ -2991,7 +3299,7 @@ Find the steady periodic solution to
 $x'' + \pi^2 x = F(t)$.  Express your solution as a series.
 \end{exercise}
 
-\setcounter{exercise}{100}
+
 
 \begin{exercise}
 Let $F(t) = \sin(2\pi t) + 0.1 \cos(10 \pi t)$.
@@ -3038,8 +3346,7 @@ $x =
 (1-n^2)} \cos (n \pi t)$
 }
 
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \sectionnewpage
 \section{PDEs, separation of variables, and the heat equation}

--- a/ch-higher-order-ode.tex
+++ b/ch-higher-order-ode.tex
@@ -110,11 +110,8 @@ exponential.  Let us review some of their properties:
 \end{align*}
 
 
-\begin{exercise}
-Derive these properties using the definitions of $\sinh$
+Exercise: Derive these properties using the definitions of $\sinh$
 and $\cosh$ in terms of exponentials.
-\end{exercise}
-
 
 Linear equations have nice and simple
 answers to the existence and uniqueness question.
@@ -261,10 +258,52 @@ homogeneous equations.
 \begin{exercise}
 Show that $y=e^x$ and $y=e^{2x}$ are linearly independent.
 \end{exercise}
+\exsolution{%
+Let $y_1=e^x$ and $y_2=e^2x$. If they're linearly \emph{independent} then $y_2=Ay_1$ where $A$ cannot be a constant independent of $x$. 
+\[
+A=\frac{y_2}{y_1}=e^x
+\]
+$A$ clearly depends on $x$ so the two solutions are linearly \emph{independent}. 
+}
+
+\begin{exercise}
+Are $\sin(x)$ and $e^x$ linearly independent?  Justify.
+\end{exercise}
+\exsol{%
+Yes.  To justify try to find a constant $A$ such that $\sin(x) = A e^x$
+for all $x$.
+}
+
+\begin{exercise}
+Are $e^x$ and $e^{x+2}$ linearly independent?  Justify.
+\end{exercise}
+\exsol{%
+No.  $e^{x+2} = e^2 e^x$.
+}
 
 \begin{exercise}
 Take $y'' + 5 y = 10 x + 5$.  Find (guess!) a solution.
 \end{exercise}
+\exsol{%
+$y=2x+1$
+}
+
+\begin{exercise}
+Guess a solution to $y'' + y' + y= 5$.
+\end{exercise}
+\exsol{%
+$y=5$
+}
+
+\begin{exercise}
+Write down an equation (guess) for which we have the solutions
+$e^x$ and $e^{2x}$.  Hint: Try an equation of the form
+$y''+Ay'+By = 0$ for constants $A$ and $B$,
+plug in both $e^x$ and $e^{2x}$ and solve for $A$ and $B$.
+\end{exercise}
+\exsol{%
+$y''-3y'+2y = 0$
+}
 
 \begin{exercise}
 Prove the superposition principle for nonhomogeneous equations.  Suppose that
@@ -272,12 +311,47 @@ $y_1$ is a solution to $L y_1 = f(x)$ and $y_2$ is a solution to
 $L y_2 = g(x)$ (same linear operator $L$).  Show that $y = y_1+y_2$ solves
 $Ly = f(x) + g(x)$.
 \end{exercise}
+\exsolution{%
+From $Ly=f(x)+g(x)$
+\[
+Ly_1+Ly_2=f(x)+g(x)
+\]
+\begin{equation*}
+\underbrace{(Ly_1-f(x))}_{=0,\ \textrm{from}\ Ly_1=f(x)}+\underbrace{(Ly_2-g(x))}_{=0\ \textrm{from}\ Ly_2=g(x)}=0
+\end{equation*}
+}
 
 \begin{exercise}
 For the equation $x^2 y'' - x y' = 0$, find two solutions, show that they
 are linearly independent and find the general solution.
 Hint: Try $y = x^r$.
 \end{exercise}
+\exsolution{%
+\[
+y=x^r,\quad y'=rx^{r-1},\quad y''=r(r-1)x^{r-2}
+\]
+Plugging into the ODE
+\[
+r(r-1)x^r-rx^r=0\quad \rightarrow r^2-2r=0
+\]
+So $r=0$ or $2$. The two solutions are $y_1=1$ and $y_2=x^2$. Checking for linear dependence
+\[
+A=\frac{y_2}{y_1}=x^2 \neq \textrm{const}
+\] 
+So the solutions are linearly independent. The general solution is
+\[
+y=c_1+c_2x^2
+\]
+}
+
+\begin{exercise}
+Find the general solution to
+$x y'' + y' = 0$.  Hint: It is a first order ODE in $y'$.
+\end{exercise}
+\exsol{%
+$y=C_1 \ln(x) + C_2$
+}
+
 
 \pagebreak[2]
 Equations of the form $a x^2 y'' + b x y' + c y = 0$ are called
@@ -296,6 +370,15 @@ $r$.
 \task What happens when ${(b-a)}^2-4ac = 0$ or ${(b-a)}^2-4ac < 0$?
 \end{tasks}
 \end{exercise}
+\exsol{%
+(a) $y=c_1x^{r_1}+c_2x^{r_2}$ where
+\begin{equation*}
+r_1=\frac{-(b-1)+\sqrt{(b-a)^2-4ac}}{2a},\quad r_2=\frac{-(b-1)-\sqrt{(b-a)^2-4ac}}{2a}
+\end{equation*}
+Where $r_1$ and $r_2$ are real and distinct, since $(b-a)^2-4ac >0$ under the square root.  \\
+(b) If equal to 0, then $r_1=r_2=r$. We would need to find another linearly independent solution since the two terms in the solution in part (a) become linearly dependent now. \\
+If $<0$ then $r_1$ and $r_2$ become complex numbers (this case is dealt with in the following section). \\
+}
 
 We will revisit the case when ${(b-a)}^2-4ac < 0$ later.
 
@@ -305,7 +388,9 @@ Suppose ${(b-a)}^2-4ac = 0$.  Find a formula for the general solution
 of $a x^2 y'' + b x y' + c y = 0$.  Hint: Try $y=x^r \ln x$ for the second
 solution.
 \end{exercise}
-
+\exsol{%
+$y=c_1x^{(a-b)/2a}+c_2x^{(a-b)/2a}\ln x$
+}
 
 \begin{exercise}[reduction of order] \label{exercise:reductionoforder}
 Suppose $y_1$ is a solution to $y'' + p(x) y' + q(x) y = 0$.
@@ -316,6 +401,22 @@ y_2(x) = y_1(x) \int \frac{e^{-\int p(x)\,dx}}{{\bigl(y_1(x)\bigr)}^2} \,dx
 \end{equation*}
 is also a solution.
 \end{exercise}
+\exsolution{%
+\begin{equation*}
+y_2'=\frac{e^{-\int p(x) dx}}{y_1}+y_1'\int\frac{e^{-\int p(x)dx}}{y_1^2}dx
+\end{equation*}
+\begin{equation*}
+y''_2=y_1''\int\frac{e^{-\int p(x)dx}}{y_1^2}dx-p(x)\frac{e^{-\int p(x)dx}}{y_1}
+\end{equation*}
+Plugging into the ODE and simplifying
+\begin{equation*}
+y_1''\int\frac{e^{-\int p(x)dx}}{y_1^2}dx+p(x)y_1'\int\frac{e^{-\int p(x)dx}}{y_1^2}dx+q(x)y_1\int\frac{e^{-\int p(x)dx}}{y_1^2}dx=0
+\end{equation*}
+\begin{equation*}
+\int\frac{e^{-\int p(x)dx}}{y_1^2}dx\underbrace{\left(y_1''+p(x)y_1'+q(x)y_1\right)}_{=\ 0\ \textrm{since}\ y_1\  \textrm{is a solution}}=0
+\end{equation*}
+Therefore $y_2=y_1\int\frac{e^{-\int p(x)dx}}{y_1^2}dx$ is also a solution.
+}
 
 \begin{exercise}[\myindex{Chebyshev's equation of order 1}]
 Take 
@@ -326,6 +427,31 @@ $(1-x^2)y''-xy' + y = 0$.
 \task Write down the general solution.
 \end{tasks}
 \end{exercise}
+\exsolution{%
+(a)
+\[
+y=x,\quad y'=1,\quad y''=0
+\]
+Plugging into the ODE gives
+\[
+0-x+x=0
+\]
+\\
+(b)
+The second solution can either be derived from $y_2=y_1v(x)$ and plugging into the ODE to find the solution for $v(x)$, or by applying the result of that directly using the reduction of order formula
+\begin{equation*}
+y_2=y_1\int\frac{e^{-\int p(x)dx}}{y_1^2}dx=x\int\frac{e^{-\int\frac{-x}{1-x^2}dx}}{x^2}dx
+\end{equation*}
+\begin{equation*}
+y_2=x\int \frac{\lvert 1-x^2 \rvert^{-1/2}}{x^2}dx=\begin{cases}
+& -\sqrt{1-x^2},\quad -1\leq x \leq 1 \\
+& \sqrt{x^2-1},\quad \textrm{otherwise}
+\end{cases}
+\end{equation*}
+\\
+(c)
+$y=c_1x+c_2\sqrt{\lvert 1-x^2\rvert}$ where the sign difference is absorbed in the constant. 
+}
 
 \begin{exercise}[\myindex{Hermite's equation of order 2}]
 Take 
@@ -337,48 +463,17 @@ $y''-2xy' + 4y = 0$.
 \task Write down the general solution.
 \end{tasks}
 \end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Are $\sin(x)$ and $e^x$ linearly independent?  Justify.
-\end{exercise}
 \exsol{%
-Yes.  To justify try to find a constant $A$ such that $\sin(x) = A e^x$
-for all $x$.
+(b) $y_2=(1-2x^2)\int_0^x\frac{e^{t^2}}{(1-2t^2)^2}dt$ \\
+(c) $y=c_1(1-2x^2)+c_2(1-2x^2)\int_0^x\frac{e^{t^2}}{(1-2t^2)^2}dt$
 }
 
-\begin{exercise}
-Are $e^x$ and $e^{x+2}$ linearly independent?  Justify.
-\end{exercise}
-\exsol{%
-No.  $e^{x+2} = e^2 e^x$.
-}
 
-\begin{exercise}
-Guess a solution to $y'' + y' + y= 5$.
-\end{exercise}
-\exsol{%
-$y=5$
-}
 
-\begin{exercise}
-Find the general solution to
-$x y'' + y' = 0$.  Hint: It is a first order ODE in $y'$.
-\end{exercise}
-\exsol{%
-$y=C_1 \ln(x) + C_2$
-}
 
-\begin{exercise}
-Write down an equation (guess) for which we have the solutions
-$e^x$ and $e^{2x}$.  Hint: Try an equation of the form
-$y''+Ay'+By = 0$ for constants $A$ and $B$,
-plug in both $e^x$ and $e^{2x}$ and solve for $A$ and $B$.
-\end{exercise}
-\exsol{%
-$y''-3y'+2y = 0$
-}
+
+
+
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -426,9 +521,7 @@ r^2 -6 r +8 & = 0 \qquad \text{(divide through by } e^{rx} \text{)},\\
 Hence, if $r=2$ or $r=4$, then $e^{rx}$ is a solution.  So let $y_1 = e^{2x}$
 and $y_2 = e^{4x}$.
 
-\begin{exercise}
-Check that $y_1$ and $y_2$ are solutions.
-\end{exercise}
+Verify: Check that $y_1$ and $y_2$ are solutions.
 
 The functions $e^{2x}$ and $e^{4x}$ are linearly independent.  If they
 were not linearly independent, we could write $e^{4x} = C e^{2x}$ for
@@ -539,9 +632,8 @@ double root $r_1 = r_2 = 4$.  The general solution is, therefore,
 y = (C_1 + C_2 x)\, e^{4 x} = C_1 e^{4x} + C_2 x e^{4x} .
 \end{equation*}
 
-\begin{exercise}
-Check that $e^{4x}$ and $x e^{4x}$ are linearly independent.
-\end{exercise}
+Verify: Check that $e^{4x}$ and $x e^{4x}$ are linearly independent.
+
 
 That $e^{4x}$ solves the equation is clear.  If $x e^{4x}$ solves the
 equation, then we know we are done.  Let us compute
@@ -609,8 +701,7 @@ $i$ and $-i$ are the two roots of $r^2 + 1 = 0$.
 Engineers often use the letter $j$ instead of $i$ for the square
 root of $-1$.  We use the mathematicians' convention and use $i$.
 
-\begin{exercise}
-Make sure you understand (that you can justify)
+Verify: make sure you understand (that you can justify)
 the following identities:
 \begin{tasks}(2)
 \task $i^2 = -1$, $i^3 = -i$, $i^4 = 1$,
@@ -620,7 +711,7 @@ the following identities:
 \task $\frac{1}{3-2i} = \frac{1}{3-2i} \frac{3+2i}{3+2i} = \frac{3+2i}{13}
 = \frac{3}{13}+\frac{2}{13}i$.
 \end{tasks}
-\end{exercise}
+
 
 \pagebreak[2]
 We also define the exponential $e^{a+ib}$ of a complex number.  We do
@@ -645,17 +736,15 @@ e^{- i \theta} = \cos \theta - i \sin \theta .
 
 In other words, $e^{a+ib} = e^a \bigl( \cos(b) + i \sin(b) \bigr) = e^a \cos(b) + i e^a \sin(b)$.
 
-\begin{exercise}
-Using Euler's formula, check the identities:
+Verify: using Euler's formula, check the identities:
 \begin{equation*}
 \cos \theta = \frac{e^{i \theta} + e^{-i \theta}}{2}
 \qquad \text{and} \qquad
 \sin \theta = \frac{e^{i \theta} - e^{-i \theta}}{2i}.
 \end{equation*}
-\end{exercise}
 
-\begin{exercise}
-Double angle identities:
+
+Verify: Double angle identities:
 Start with $e^{i(2\theta)} = {\bigl(e^{i \theta} \bigr)}^2$.  Use Euler on
 each side and deduce:
 \begin{equation*}
@@ -663,7 +752,7 @@ each side and deduce:
 \qquad \text{and} \qquad
 \sin (2\theta) = 2 \sin \theta \cos \theta .
 \end{equation*}
-\end{exercise}
+
 
 For a complex number $a+ib$ we call
 $a$ the \emph{\myindex{real part}} and $b$ the \emph{\myindex{imaginary part}} of the number.
@@ -775,58 +864,23 @@ y = 5 e^{3x} \sin (2x) .
 \begin{exercise}
 Find the general solution of $2y'' + 2y' -4 y = 0$.
 \end{exercise}
+\exsolution{%
+Writing the characteristic equation
+\[
+2r^2+2r-4=0
+\]
+Solving, we get $r_1=1$, $r_2=-2$. The general solution is
+\[
+y=C_1e^x+C_2e^{-2x}
+\]
+}
 
 \begin{exercise}
 Find the general solution of $y'' + 9y' - 10 y = 0$.
 \end{exercise}
-
-\begin{exercise}
-Solve $y'' - 8y' + 16 y = 0$ for $y(0) = 2$, $y'(0) = 0$.
-\end{exercise}
-
-\begin{exercise}
-Solve $y'' + 9y' = 0$ for $y(0) = 1$, $y'(0) = 1$.
-\end{exercise}
-
-\begin{exercise}
-Find the general solution of $2y'' + 50y = 0$.
-\end{exercise}
-
-\begin{exercise}
-Find the general solution of $y'' + 6 y' + 13 y = 0$.
-\end{exercise}
-
-\begin{exercise}
-Find the general solution of $y'' = 0$ using the methods of this section.
-\end{exercise}
-
-\begin{exercise}
-The method of this section applies to equations of other orders than two.
-We will see
-higher orders later.  Try to solve the first order equation
-$2y' + 3y = 0$ using the methods of this section.
-\end{exercise}
-
-\begin{exercise}
-Let us revisit the Cauchy--Euler equations\index{Cauchy--Euler equation} of
-\exercisevref{sol:eulerex}.  Suppose now
-that ${(b-a)}^2-4ac < 0$.  Find a formula for the general solution
-of $a x^2 y'' + b x y' + c y = 0$.  Hint: Note that $x^r = e^{r \ln x}$.
-\end{exercise}
-
-\begin{exercise}
-Find the solution to
-$y''-(2\alpha) y' + \alpha^2 y=0$, $y(0) = a$, $y'(0)=b$,
-where $\alpha$, $a$, and $b$ are real numbers.
-\end{exercise}
-
-\begin{exercise}
-Construct an equation such that $y = C_1 e^{-2x} \cos(3x) + C_2 e^{-2x}
-\sin(3x)$ is the general
-solution.
-\end{exercise}
-
-\setcounter{exercise}{100}
+\exsol{%
+$y=C_1e^{10x}+C_2e^{-x}$
+}
 
 \begin{exercise}
 Find the general solution to
@@ -848,6 +902,70 @@ $y =
 C_1 e^{3x}
 +
 C_2 x e^{3x}$
+}
+
+\begin{exercise}
+Solve $y'' - 8y' + 16 y = 0$ for $y(0) = 2$, $y'(0) = 0$.
+\end{exercise}
+\exsolution{%
+The characteristic equation is
+\[
+r^2-8r+16=0
+\]
+Solving, we find $r_1=r_2=4$. So the general solutions is
+\[
+y=C_1e^{4x}+C_2xe^{4x}
+\]
+Applying the initial conditions
+\[
+y(0)=C_1=2
+\]
+\[
+y'(0)=8e^{4x}+4C_2xe^{4x}+C_2e^{4x}\quad \rightarrow y'(0)=8+C_2=0\quad \rightarrow C_2=-8
+\]
+Therefore the solution is
+\[
+y=2e^{4x}-8xe^{4x}
+\]
+}
+
+\begin{exercise}
+Solve $y'' + 9y' = 0$ for $y(0) = 1$, $y'(0) = 1$.
+\end{exercise}
+\exsol{%
+$y=\frac{1}{9}\left(10-e^{-9x}\right)$
+}
+
+\begin{exercise}
+Find the general solution of $2y'' + 50y = 0$.
+\end{exercise}
+\exsolution{%
+The characteristic equation is 
+\[
+r^2+25=0\quad \rightarrow r_1,r_2=\pm i5
+\]
+Here $\alpha=0$ and $\beta=5$. Therefore the general solution is
+\[
+y=C_1\cos (5x)+C_2\sin(5x)
+\]
+}
+
+\begin{exercise}
+Find the general solution of $y'' + 6 y' + 13 y = 0$.
+\end{exercise}
+\exsolution{%
+The characteristic equation is 
+\[
+r^2+6r+13=0 
+\]
+Using the quadratic formula
+\begin{equation*}
+r_1,r_2= -3\pm \frac{\sqrt{36-49}}{2}=\underbrace{-3}_{\alpha}\pm \underbrace{i\frac{\sqrt{13}}{2}}_{\beta}
+\end{equation*}
+Therefore the general solution is
+\begin{equation*}
+y=C_1e^{-3x}\cos(\frac{\sqrt{13}}{2}x)+C_2e^{-3x}\sin(\frac{\sqrt{13}}{2}x)
+\end{equation*}
 }
 
 \begin{exercise}
@@ -880,6 +998,60 @@ $z(t) =
 }
 
 \begin{exercise}
+Find the general solution of $y'' = 0$ using the methods of this section.
+\end{exercise}
+\exsol{%
+$y=C_1+xC_2$
+}
+
+\begin{exercise}
+The method of this section applies to equations of other orders than two.
+We will see
+higher orders later.  Try to solve the first order equation
+$2y' + 3y = 0$ using the methods of this section.
+\end{exercise}
+\exsol{%
+$y=ce^{-2/3x}$
+}
+
+\begin{exercise}
+Let us revisit the Cauchy--Euler equations\index{Cauchy--Euler equation} of
+\exercisevref{sol:eulerex}.  Suppose now
+that ${(b-a)}^2-4ac < 0$.  Find a formula for the general solution
+of $a x^2 y'' + b x y' + c y = 0$.  Hint: Note that $x^r = e^{r \ln x}$.
+\end{exercise}
+\exsolution{%
+As was done in \exercisevref{sol:eulerex}
+\[
+y=x^r,\quad y'=rx^{r-1},\quad y''=r(r-1)x^{r-2}
+\]
+Plugging into the ODE and simplifying
+\[
+ar^2+(b-a)r+c=0
+\]
+Solving for $r$
+\[
+r_1,r_2=\frac{a-b}{2a}\pm i \frac{\sqrt{4ac-(b-a)^2}}{2a}
+\]
+Using Euler's formula
+\begin{equation*}
+y=e^{\frac{a-b}{2a}\ln x}\left[C_1\cos(\frac{\sqrt{4ac-(b-a)^2}}{2a} \ln x)+C_2 \sin(\frac{\sqrt{4ac-(b-a)^2}}{2a} \ln x)\right]
+\end{equation*}
+\begin{equation*}
+y=x^{\frac{a-b}{2a}}\left[C_1\cos(\frac{\sqrt{4ac-(b-a)^2}}{2a} \ln x)+C_2 \sin(\frac{\sqrt{4ac-(b-a)^2}}{2a} \ln x)\right]
+\end{equation*}
+}
+
+\begin{exercise}
+Find the solution to
+$y''-(2\alpha) y' + \alpha^2 y=0$, $y(0) = a$, $y'(0)=b$,
+where $\alpha$, $a$, and $b$ are real numbers.
+\end{exercise}
+\exsol{%
+$y=ae^{\alpha x}+(b-\alpha a)xe^{\alpha x}$
+}
+
+\begin{exercise}
 Find the solution to
 $y''-(\alpha+\beta) y' + \alpha \beta y=0$, $y(0) = a$, $y'(0)=b$,
 where $\alpha$, $\beta$, $a$, and $b$ are real numbers, and $\alpha \not=
@@ -892,12 +1064,30 @@ $y =
 }
 
 \begin{exercise}
+Construct an equation such that $y = C_1 e^{-2x} \cos(3x) + C_2 e^{-2x}
+\sin(3x)$ is the general
+solution.
+\end{exercise}
+\exsolution{%
+From the solution given $\alpha=-2$, and $\beta=3$ giving 
+\[
+r_1,r_2=-2\pm i3 \quad \rightarrow (r+2-i3)(r+2+i3)=r^2+4r+13=0
+\]
+An ODE that has this characteristic equation is
+\[
+y''+4y'+13y=0
+\]
+}
+
+\begin{exercise}
 Construct an equation such that $y = C_1 e^{3x} + C_2 e^{-2x}$ is the general
 solution.
 \end{exercise}
 \exsol{%
 $y'' -y'-6y=0$
 }
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1234,14 +1424,46 @@ a computer or an advanced calculator for the roots.
 \begin{exercise}
 Find the general solution for $y''' - y'' + y' - y = 0$.
 \end{exercise}
+\exsolution{%
+The characteristic equation is
+\begin{align*}
+r^3-r^2+3-1 &=0 \\
+(r^2+1)(r-1) &=0\quad \rightarrow r_1=1,\ r_2=i,\ r_3=-i
+\end{align*}
+Therefore the general solution is
+\begin{align*}
+y=C_1e^x+C_2\cos x +C_3\sin x
+\end{align*}
+}
 
 \begin{exercise}
 Find the general solution for $y^{(4)} - 5 y''' + 6 y'' = 0$.
 \end{exercise}
+\exsol{%
+$y=C_1+C_2x+C_3e^{2x}+C_4e^{3x}$
+}
 
 \begin{exercise}
 Find the general solution for $y''' + 2 y'' + 2 y' = 0$.
 \end{exercise}
+\exsol{%
+$y=C_1+e^{-x}\left( C_2\cos x+C_3 \sin x\right)$
+}
+
+\begin{exercise}
+Find the general solution of $y^{(5)}-y^{(4)}=0$.
+\end{exercise}
+\exsol{%
+$y=C_1 e^x +C_2 x^3 + C_3 x^2 +C_4 x + C_5$
+}
+
+\begin{exercise}
+Solve $1001y'''+3.2y''+\pi y'-\sqrt{4} y = 0$, $y(0)=0$, $y'(0) = 0$,
+$y''(0) = 0$.
+\end{exercise}
+\exsol{%
+$y=0$
+}
 
 \begin{exercise}
 Suppose the characteristic equation for an ODE is
@@ -1253,62 +1475,21 @@ Find such a differential equation.
 Find its general solution.
 \end{tasks}
 \end{exercise}
-
-\begin{exercise} \label{hol:eqfromsolex}
-Suppose that a fourth order equation has a solution
-$y = 2 e^{4x} x \cos x$.  
-\begin{tasks}
-\task
-Find such an equation.
-\task
-Find the initial conditions that the given
-solution satisfies.
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-Find the general solution for the equation of \exerciseref{hol:eqfromsolex}.
-\end{exercise}
-
-\begin{exercise}
-Let
-$f(x) = e^x - \cos x$, $g(x) = e^x + \cos x$, and $h(x) = \cos x$.
-Are $f(x)$, $g(x)$, and $h(x)$
-linearly independent?  If so, show
-it, if not, find a linear combination that works.
-\end{exercise}
-
-\begin{exercise}
-Let
-$f(x) = 0$, $g(x) = \cos x$, and $h(x) = \sin x$.
-Are $f(x)$, $g(x)$, and $h(x)$
-linearly independent?  If so, show
-it, if not, find a linear combination that works.
-\end{exercise}
-
-\begin{exercise}
-Are $x$, $x^2$, and $x^4$
-linearly independent?  If so, show
-it, if not, find a linear combination that works.
-\end{exercise}
-
-\begin{exercise}
-Are $e^x$, $xe^x$, and $x^2e^x$
-linearly independent?  If so, show
-it, if not, find a linear combination that works.
-\end{exercise}
-
-\begin{exercise}
-Find an equation such that $y=xe^{-2x}\sin(3x)$ is a solution.
-\end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Find the general solution of $y^{(5)}-y^{(4)}=0$.
-\end{exercise}
-\exsol{%
-$y=C_1 e^x +C_2 x^3 + C_3 x^2 +C_4 x + C_5$
+\exsolution{%
+a) Expanding the characteristic equation
+\begin{align*}
+(r^2-2r+1)(r^2-4r+4) &=0 \\
+r^4-6r^3+13r^2-12r+4 &= 0
+\end{align*}
+Therefore an ODE with such a characteristic equation is
+\begin{align*}
+y^{(4)}-6y'''+13y''-12y'+4y=0
+\end{align*}
+\\
+b) Since $r_1=r_2=1$ and $r_3=r_4=2$ the general solution is
+\begin{align*}
+y=(C_1+C_2x)e^x+(C_3+C_4x)e^{2x}
+\end{align*}
 }
 
 \begin{exercise}
@@ -1334,12 +1515,138 @@ b) $y'''-3y''+4y'-12y = 0$
 c) $y = C_1 e^{3x} + C_2 \sin(2x) + C_3 \cos(2x)$
 }
 
+\begin{exercise} \label{hol:eqfromsolex}
+Suppose that a fourth order equation has a solution
+$y = 2 e^{4x} x \cos x$.  
+\begin{tasks}
+\task
+Find such an equation.
+
+\task Find the general solution to the above equation. 
+\task
+Find the initial conditions that the given
+solution satisfies at $x=0$. Note: You might like to use a computer algebra system like Wolframalpha to take the derivatives.
+
+
+\end{tasks}
+\end{exercise}
+\exsolution{%
+a) The appearance of $\cos x$ means there are two complex roots with $r=4\pm i $. Furthermore, the appearance of $x$ means that these roots are repeated, so
+\begin{align*}
+r_1=r_2 &=4+i \\
+r_3=r_4 &=4-i \\
+\end{align*}
+The resulting characteristic equation after expanding is
+\begin{align*}
+r^3-16r^3+98r^2-272r+289=0
+\end{align*}
+Giving an ODE
+\begin{align*}
+y^{(4)}-16y'''+98y''-272y'+289y=0
+\end{align*}
+\\
+b) $y=(C_1+C_2x)e^{4x}\cos x-(C_3+C_4x)e^{4x}\sin x$\\
+c) Try $y(0)=2e^0(0)\cos(0)=0$, so the first initial condition is $y(0)=0$. Differentiating
+\begin{align*}
+y' &=2e^{4x}(-x\sin x+\cos x)+8e^{4x}x\cos x \\
+y'(0) &= 2
+\end{align*}
+Differentiating again 
+\begin{align*}
+y'' &= 2e^{4x}\left[(15x+8)\cos x-2(4x+1)\sin x\right] \\
+y''(0) &= 16
+\end{align*}
+Differentiating yet again
+\begin{align*}
+y''' &= 2e^{4x}\left[(52x+45)\cos x-(47x+24)\sin x\right] \\
+y'''(0) &= 90
+\end{align*}
+So the initial conditions are $y(0)=0,\ y'(0)=2,\ y''(0)=16,\ y'''(0)=90$.
+}
+
+
+
 \begin{exercise}
-Solve $1001y'''+3.2y''+\pi y'-\sqrt{4} y = 0$, $y(0)=0$, $y'(0) = 0$,
-$y''(0) = 0$.
+Find an equation such that $y=\cos(x)$, $y=\sin(x)$, $y=e^x$ are solutions.
 \end{exercise}
 \exsol{%
-$y=0$
+$y'''-y''+y'-y=0$
+}
+
+\begin{exercise}
+Find an equation such that $y=xe^{-2x}\sin(3x)$ is a solution.
+\end{exercise}
+\exsol{%
+$y^{(4)}+8y'''+42y''+104y'+169y=0$
+}
+
+\begin{exercise}
+Let
+$f(x) = e^x - \cos x$, $g(x) = e^x + \cos x$, and $h(x) = \cos x$.
+Are $f(x)$, $g(x)$, and $h(x)$
+linearly independent?  If so, show
+it, if not, find a linear combination that works.
+\end{exercise}
+\exsolution{%
+We want to write
+\begin{align*}
+c_1f(x)+c_2g(x)+c_3h(x)=0
+\end{align*}
+And find whether this is satisfied for any combination of coefficients $c_i$ (linearly dependent), or if $c_i=0$ is the only solution (linear independent). This equation should be satisfied for any choice of $x$ so first we set $x=0$
+\begin{align*}
+2c_2+c_3 &=0\quad \rightarrow c_3=-2c_2 \\
+c_1f(x)+c_2(g(x)-2h(x))&=0
+\end{align*}
+This equation should again be satisfied for any $x$, we choose $x=\pi/2$
+\begin{align*}
+c_1e^{\pi/2}+c_2(e^{\pi/2}-0) &=0\quad \rightarrow c_2=-c_1 \\
+c_1(f(x)-g(x)+2h(x)) &=0 \\
+c_1(e^x-\cos x-e^x-\cos x+2\cos x)&=0
+\end{align*}
+So $c_1$ is a free parameter, therefore $f(x), g(x)$ and $h(x)$ are linearly dependent. Choosing $c_1=1\quad \rightarrow c_2=-1,\ c_3=2$ we get the combination
+\begin{align*}
+(e^x-\cos x)-(e^x+\cos x)+2\cos x=0
+\end{align*}
+}
+
+\begin{exercise}
+Let
+$f(x) = 0$, $g(x) = \cos x$, and $h(x) = \sin x$.
+Are $f(x)$, $g(x)$, and $h(x)$
+linearly independent?  If so, show
+it, if not, find a linear combination that works.
+\end{exercise}
+\exsol{%
+No, choosing $c_1=1,\ c_2=c_3=0$ we get $1(0)+0(\cos x)+0(\sin x)=0$.
+}
+
+\begin{exercise}
+Are $x$, $x^2$, and $x^4$
+linearly independent?  If so, show
+it, if not, find a linear combination that works.
+\end{exercise}
+\exsolution{%
+We write 
+\begin{align*}
+c_1x+c_2x^2+c_3x^4=0
+\end{align*}
+We differentiate a few times
+\begin{align*}
+c_1+2c_2x+4c_3x^3 &=0 \\
+2c_2+12c_3x^2 &=0 \\
+24c_3x &=0 \\
+24c_3 &=0\quad \rightarrow c_3=0 
+\end{align*}
+Plugging $c_3=0$ back in and repeating the process, we find that $c_1=c_2=0$. So the functions are linearly independent. 
+}
+
+\begin{exercise}
+Are $e^x$, $xe^x$, and $x^2e^x$
+linearly independent?  If so, show
+it, if not, find a linear combination that works.
+\end{exercise}
+\exsol{%
+Yes. Divide the equation by $e^x$, then differentiate twice to find $c_3=0$ and consequently $c_1=c_2=0$. 
 }
 
 \begin{exercise}
@@ -1359,12 +1666,9 @@ Yes.  (Hint: First note that $\sin(x)$ is bounded.  Then note that
 $x$ and $x\sin(x)$ cannot be multiples of each other.)
 }
 
-\begin{exercise}
-Find an equation such that $y=\cos(x)$, $y=\sin(x)$, $y=e^x$ are solutions.
-\end{exercise}
-\exsol{%
-$y'''-y''+y'-y=0$
-}
+
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1536,14 +1840,13 @@ It is not hard to compute that $C= \sqrt{A^2 + B^2}$ and $\tan \gamma =
 $C$ and $\gamma$ be our arbitrary constants and write
 $x(t) = C \cos ( \omega_0 t - \gamma )$.
 
-\begin{exercise}
-Justify the identity $A \cos (\omega_0 t) + B \sin (\omega_0 t) =
+Verify: Justify the identity $A \cos (\omega_0 t) + B \sin (\omega_0 t) =
 C \cos ( \omega_0 t - \gamma )$ and verify the equations for $C$
 and $\gamma$.  Hint: Start with
 $\cos (\alpha-\beta) = \cos (\alpha) \cos
 (\beta) + \sin (\alpha)\sin (\beta)$ and multiply by $C$.  Then what should
 $\alpha$ and $\beta$ be?
-\end{exercise}
+
 
 While it is generally easier to use the first form with $A$ and $B$
 to solve for the initial conditions, the second form is much
@@ -1836,67 +2139,6 @@ flatter as $c$ (and hence $p$) goes to 0.
 
 \subsection{Exercises}
 
-\begin{samepage}
-\begin{exercise} \label{mv:ex1}
-Consider a mass and spring system with a mass $m=2$, spring constant $k=3$, and
-damping constant $c=1$.
-\begin{tasks}
-\task Set up and find the general solution of the system.
-\task Is the system underdamped, overdamped or critically damped?
-\task If the system is not critically damped, find a $c$ that makes the system
-critically damped.
-\end{tasks}
-\end{exercise}
-\end{samepage}
-
-\begin{exercise}
-Do \exerciseref{mv:ex1} for
-$m=3$, $k=12$, and $c=12$.
-\end{exercise}
-
-\begin{exercise} \label{mv:exwt1}
-Using the mks units (meters-kilograms-seconds)\index{mks units},
-suppose you have a spring with spring constant \unitfrac[4]{N}{m}.
-You want to use
-it to weigh items.  Assume no friction.  You place the mass on
-the spring and put it in motion.
-\begin{tasks}
-\task You count and find that the frequency is
-\unit[0.8]{Hz} (cycles per second).  What is the mass?
-\task Find a formula for the mass $m$
-given the frequency $\omega$ in \unit{Hz}.
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-Suppose we add possible friction to \exerciseref{mv:exwt1}.
-Further, suppose you do not know the spring constant, but you have
-two reference weights \unit[1]{kg} and \unit[2]{kg} to calibrate your setup.
-You put each in motion on your spring and measure the
-frequency.  For the \unit[1]{kg}
-weight you measured \unit[1.1]{Hz}, for the \unit[2]{kg} weight you
-measured \unit[0.8]{Hz}.
-\begin{tasks}
-\task Find $k$ (spring constant) and $c$ (damping constant).
-\task Find a formula for the mass in terms of the frequency in Hz.  \emph{Note that
-there may be more than one possible mass for a given frequency.}
-\task For an unknown object you measured \unit[0.2]{Hz}, what is the mass of the
-object?  Suppose that you know that the mass of the unknown object
-is more than a kilogram.
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-Suppose you wish to measure the friction a mass of \unit[0.1]{kg} experiences
-as it slides along a floor (you wish to find $c$).  You have a spring with
-spring constant $k=\unitfrac[5]{N}{m}$.  You take the spring, you attach it
-to the mass and fix it to a wall.  Then you pull on the spring and let the
-mass go.  You find that the mass oscillates with frequency \unit[1]{Hz}.
-What is the friction?
-\end{exercise}
-
-\setcounter{exercise}{100}
-
 \begin{exercise}
 A mass of $2$ kilograms is on a spring with spring constant $k$ newtons per
 meter with no damping.  Suppose the system is at rest and at time $t=0$ the
@@ -1906,25 +2148,6 @@ from the rest position?
 \end{exercise}
 \exsol{%
 $k=\nicefrac{8}{9}$ (and larger)
-}
-
-\begin{exercise}
-Suppose we have an RLC circuit with a resistor of 100 milliohms (0.1 ohms),
-inductor of inductance of 50 millihenries (0.05 henries), and a capacitor of 5 farads, with
-constant voltage.
-\begin{tasks}
-\task Set up the ODE equation for the current $I$.
-\task Find the general solution.
-\task Solve for $I(0) = 10$ and $I'(0) = 0$.
-\end{tasks}
-\end{exercise}
-\exsol{%
-a) $0.05 I'' + 0.1 I' + (\nicefrac{1}{5}) I = 0$
-\quad
-b) $I = C e^{-t} \cos(\sqrt{3} \, t - \gamma)$
-\quad
-c) $I = 10 e^{-t} \cos(\sqrt{3} \, t) + \frac{10}{\sqrt{3}} e^{-t}
-\sin(\sqrt{3} \, t)$
 }
 
 \begin{exercise}
@@ -1953,6 +2176,55 @@ c) \unit[45000]{kg}
 d) \unit[11250]{kg}
 }
 
+\begin{samepage}
+\begin{exercise} \label{mv:ex1}
+Consider a mass and spring system with a mass $m=2$, spring constant $k=3$, and
+damping constant $c=1$.
+\begin{tasks}
+\task Set up and find the general solution of the system.
+\task Is the system underdamped, overdamped or critically damped?
+\task If the system is not critically damped, find a $c$ that makes the system
+critically damped.
+\end{tasks}
+\end{exercise}
+\end{samepage}
+\exsolution{%
+a) The general equation is 
+\begin{align*}
+mx''+cx'+kx &=0 \\
+2x''+x'+3x &=0
+\end{align*}
+The characteristic equation is
+\begin{align*}
+2r^2+r+3 &=0 \\
+r &= -\frac{1}{4}\pm i\frac{\sqrt{23}}{4}
+\end{align*} 
+So the general solution is 
+\begin{align*}
+x(t)=e^{-x/4}\left[C_1\cos(\frac{\sqrt{23}}{4}x)+C_2\sin(\frac{\sqrt{23}}{4}x)\right]
+\end{align*}
+\\
+b) From the general solution (complex roots), the system is underdamped. 
+\\
+c) For critical damping, we want 
+\begin{align*}
+c^2-4km &=0 \\
+c^2 &=4km =24 \\
+c &= \sqrt{24}\ \textrm{N.s/m}
+\end{align*} 
+Note that we choose the positive sign as $c\geq 0$.
+}
+
+\begin{exercise}
+Do \exerciseref{mv:ex1} for
+$m=3$, $k=12$, and $c=12$.
+\end{exercise}
+\exsol{%
+a) $x(t)=(C_1+C_2x)e^{-2x}$.
+b) Critically damped since we have two repeated roots.
+c) The system is critically damped.
+}
+
 \begin{exercise}
 A mass of $m$ \unit{kg} is on a spring with $k=\unitfrac[3]{N}{m}$ and
 $c=\unitfrac[2]{Ns}{m}$.  Find the mass $m_0$ for which there is critical
@@ -1963,6 +2235,118 @@ underdamped or overdamped?
 $m_0 = \frac{1}{3}$.  If $m < m_0$, then the system is overdamped and will
 not oscillate.
 }
+
+\begin{exercise}
+Suppose we have an RLC circuit with a resistor of 100 milliohms (0.1 ohms),
+inductor of inductance of 50 millihenries (0.05 henries), and a capacitor of 5 farads, with
+constant voltage.
+\begin{tasks}
+\task Set up the ODE equation for the current $I$.
+\task Find the general solution.
+\task Solve for $I(0) = 10$ and $I'(0) = 0$.
+\end{tasks}
+\end{exercise}
+\exsol{%
+a) $0.05 I'' + 0.1 I' + (\nicefrac{1}{5}) I = 0$
+\quad
+b) $I = C e^{-t} \cos(\sqrt{3} \, t - \gamma)$
+\quad
+c) $I = 10 e^{-t} \cos(\sqrt{3} \, t) + \frac{10}{\sqrt{3}} e^{-t}
+\sin(\sqrt{3} \, t)$
+}
+
+\begin{exercise} \label{mv:exwt1}
+Using the mks units (meters-kilograms-seconds)\index{mks units},
+suppose you have a spring with spring constant \unitfrac[4]{N}{m}.
+You want to use
+it to weigh items.  Assume no friction.  You place the mass on
+the spring and put it in motion.
+\begin{tasks}
+\task You count and find that the frequency is
+\unit[0.8]{Hz} (cycles per second).  What is the mass?
+\task Find a formula for the mass $m$
+given the frequency in \unit{Hz}.
+\end{tasks}
+\end{exercise}
+\exsol{%
+a) $m=\frac{4}{(1.6 \pi)^2}\approx 0.158$ kg.
+b) $m=	\frac{1}{\pi^2f^2}$.
+}
+
+\begin{exercise}
+Suppose we add possible friction to \exerciseref{mv:exwt1}.
+Further, suppose you do not know the spring constant, but you have
+two reference weights \unit[1]{kg} and \unit[2]{kg} to calibrate your setup.
+You put each in motion on your spring and measure the
+frequency.  For the \unit[1]{kg}
+weight you measured \unit[1.1]{Hz}, for the \unit[2]{kg} weight you
+measured \unit[0.8]{Hz}.
+\begin{tasks}
+\task Find $k$ (spring constant) and $c$ (damping constant).
+\task Find a formula for the mass in terms of the frequency in Hz.  \emph{Note that
+there may be more than one possible mass for a given frequency.}
+\task For an unknown object you measured \unit[0.2]{Hz}, what is the mass of the
+object?  Suppose that you know that the mass of the unknown object
+is more than a kilogram.
+\end{tasks}
+\end{exercise}
+\exsolution{%
+a) The angular frequency is $\omega_1=1.1\times 2\pi$. For a damped oscillating system
+\begin{align*}
+\omega_1 &=\sqrt{\omega_0^2-p^2} \\
+\omega_1 &= \sqrt{\frac{k}{m_1}-\frac{c^2}{4m_1^2}} \\
+\omega_1^2 &=\frac{k}{m_1}-\frac{c^2}{4m_1^2} \\
+4m_1^2\omega_1^2 &=4km_1-c^2 \quad (1)
+\end{align*}
+Similarly
+\begin{align*}
+4m_2^2\omega_2^2 &=4km_2-c^2 \quad (2)
+\end{align*}
+Subtracting equation (2) from (1) we get
+\begin{align*}
+4(m_1^2\omega_1^2-m_2^2\omega_2^2)=4k(m_1-m_2)
+\end{align*}
+Solving for $k$
+\begin{align*}
+k=\frac{m_1^2\omega_1^2-m_2^2\omega_2^2}{m_1-m_2}\approx 53.33\ \textrm{N/m}
+\end{align*}
+Plugging into (1) 
+\begin{align*}
+c=2\sqrt{km_1-m_1^2\omega_1^2}\approx 4.718\ \textrm{N.s/m}
+\end{align*}
+\\
+b) 
+\begin{align*}
+\omega=\sqrt{\frac{k}{m}-\frac{c^2}{4m^2}}
+\end{align*}
+Solving for $m$
+\begin{align*}
+m=\frac{k\pm\sqrt{k^2-c^2\omega^2}}{2\omega^2}
+\end{align*}
+Writing $\omega=2\pi f$
+\begin{align*}
+m=\frac{k\pm \sqrt{k^2-(2\pi cf)^2}}{2(2\pi f)^2}
+\end{align*}
+Note that $k\geq \sqrt{k^2-c^2\omega^2}$, so these are two possible masses for each given frequency. 
+\\
+c) For $f=0.2$, plugging into the equation above we get $m\approx.104$ kg, or $m\approx 33.67$ kg. We know the mass is greater than 1 kg so we choose the latter answer.
+}
+
+\begin{exercise}
+Suppose you wish to measure the friction a mass of \unit[0.1]{kg} experiences
+as it slides along a floor (you wish to find $c$).  You have a spring with
+spring constant $k=\unitfrac[5]{N}{m}$.  You take the spring, you attach it
+to the mass and fix it to a wall.  Then you pull on the spring and let the
+mass go.  You find that the mass oscillates with frequency \unit[1]{Hz}.
+What is the friction?
+\end{exercise}
+\exsol{%
+$c=\sqrt{4km-4\omega_1^2m^2}\approx 0.659$ N.s/m.
+}
+
+
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -2086,7 +2470,7 @@ So $6Ax+(5A+6B) = 2x+1$.  Therefore, $A = \nicefrac{1}{3}$ and $B = \nicefrac{-1
 That means
 $y_p = \frac{1}{3}\, x - \frac{1}{9} = \frac{3x-1}{9}$.
 Solving the complementary
-problem (exercise!) we get
+problem (verify!) we get
 \begin{equation*}
 y_c = C_1 e^{-2x} + C_2 e^{-3x}.
 \end{equation*}
@@ -2109,10 +2493,9 @@ y(x) = \frac{1}{3} e^{-2x} - \frac{2}{9} e^{-3x} + \frac{3x-1}{9} =
 \frac{3 e^{-2x} - 2 e^{-3x} + 3x-1}{9} .
 \end{equation*}
 
-\begin{exercise}
-Check that $y$ really solves the equation \eqref{eq3.5:nh}
+Verify: check that $y$ really solves the equation \eqref{eq3.5:nh}
 and the given initial conditions.
-\end{exercise}
+
 
 Note: A common mistake is to solve for constants using the initial
 conditions with $y_c$ and only add the particular solution $y_p$ after that.
@@ -2398,78 +2781,56 @@ y = C_1 \cos (x) + C_2 \sin (x) +
 Find a particular solution of
 $y''-y' -6y = e^{2x}$.
 \end{exercise}
+\exsolution{%
+Finding the complementary solution $y_c$
+\begin{align*}
+y_c=C_1e^{3x}+C_2e^{-2x}
+\end{align*}
+The right hand side of the ODE is an exponential, so the particular solution should look like $y_p=Ae^{2x}$. Differentiating 
+\begin{align*}
+y_p'=2Ae^{2x},\quad y_p''=4Ae^{2x}
+\end{align*}
+Plugging into the ODE, we find $A=-1/4$. Therefore, the particular solution is $y_p=-\frac{e^{2x}}{4}$. 
+}
 
 \begin{exercise}
 Find a particular solution of
 $y''-4y' +4y = e^{2x}$.
 \end{exercise}
-
-\begin{exercise}
-Solve the initial value problem
-$y''+9y = \cos (3x) + \sin (3x)$ for $y(0) = 2$, $y'(0) = 1$.
-\end{exercise}
-
-\begin{exercise}
-Set up the form of the particular solution but do not solve
-for the coefficients for $y^{(4)}-2y'''+y'' = e^x$.
-\end{exercise}
-
-\begin{exercise}
-Set up the form of the particular solution but do not solve
-for the coefficients for $y^{(4)}-2y'''+y'' = e^x + x + \sin x$.
-\end{exercise}
-
-\begin{exercise}
-\pagebreak[2]
-\leavevmode
-\begin{tasks}
-\task Using variation of parameters find a particular solution of
-$y''-2y'+y = e^x$.
-\task Find a particular solution using undetermined
-coefficients.
-\task Are the two solutions you found the same?
-See also \exerciseref{exercise:diffvarparunder}.
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-Find a particular solution of
-$y''-2y' +y = \sin (x^2)$.  It is OK to leave the answer as a definite
-integral.
-\end{exercise}
-
-\begin{exercise}
-For an arbitrary constant $c$ find a particular solution
-to $y''-y=e^{cx}$.  Hint: Make sure to handle every possible real $c$.
-\end{exercise}
-
-\begin{exercise} \label{exercise:diffvarparunder}
-\pagebreak[2]
-\leavevmode
-\begin{tasks}
-\task Using variation of parameters find a particular solution of
-$y''-y = e^x$.
-\task Find a particular solution using undetermined
-coefficients.
-\task Are the two solutions you found the same?
-What is going on?
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-Find a polynomial $P(x)$, so that
-$y = 2 x^2 + 3 x + 4$
-solves
-$y''+5 y'+ y = P(x)$.
-\end{exercise}
-
-\setcounter{exercise}{100}
+\exsol{%
+$y_p=\frac{x^2e^{2x}}{2}$
+}
 
 \begin{exercise}
 Find a particular solution to $y''-y'+y=2\sin(3x)$.
 \end{exercise}
 \exsol{%
 $y=\frac{-16\sin(3x)+6\cos(3x)}{73}$
+}
+
+\begin{exercise}
+Solve the initial value problem
+$y''+9y = \cos (3x) + \sin (3x)$ for $y(0) = 2$, $y'(0) = 1$.
+\end{exercise}
+\exsolution{%
+The complementary solution is $y_c=C_1\cos(3x)+C_2\sin(3x)$. Given the right hand side of the ODE, we expect the particular solution to be of the form $y_p=A\cos(3x)+B\sin(3x)$. This however is a duplicate of $y_c$, so we multiply by $x$, giving
+\begin{align*}
+y_p &=Ax\cos(3x)+Bx\sin(3x) \\
+y_p' &=-3Ax\sin(3x)+A\cos(3x)+3Bx\cos(3x)+B\sin(3x) \\
+y_p'' &= -9Ax\cos(3x)-6A\sin(3x)-9Bx\sin(3x)+6B\cos(3x)
+\end{align*}
+Plugging into the ODE and cancelling terms, we end up with
+\begin{align*}
+-6A\sin(3x)+6B\cos(3x)=\cos(3x)+\sin(3x)\quad \rightarrow A=-1/6,\quad B=1/6
+\end{align*}
+So the general solution is 
+\begin{align*}
+y=C_1\cos(3x)+C_2\sin(3x)+\frac{x}{6}(\sin(3x)-\cos(3x))
+\end{align*}
+Applying the initial conditions (to the full general solution including the particular solution), we find that $C_1=2$ and $C_2=7/18$, so the solution to the initial value problem is
+\begin{align*}
+y=2\cos(3x)+\frac{7}{18}\sin(3x)+\frac{x}{6}\left(\sin(3x)-\cos(3x)\right)
+\end{align*}
 }
 
 \begin{samepage}
@@ -2494,6 +2855,74 @@ $y(x) = x^2-4 x+6+e^{-x}(x-5)$
 }
 
 \begin{exercise}
+Set up the form of the particular solution but do not solve
+for the coefficients for $y^{(4)}-2y'''+y'' = e^x$.
+\end{exercise}
+\exsolution{%
+Finding the complementary solution
+\begin{align*}
+y_c=C_1+C_2x+C_3e^x+C_4xe^x
+\end{align*}
+Given the right hand side of the ODE, we guess a particualr solution of the form $y_p=Ae^x$, but this is a duplicate of a term in $y_c$ so we multiply by $x^2$ giving
+\begin{align*}
+y_p=Ax^2e^x
+\end{align*}
+}
+
+\begin{exercise}
+Set up the form of the particular solution but do not solve
+for the coefficients for $y^{(4)}-2y'''+y'' = e^x + x + \sin x$.
+\end{exercise}
+\exsol{%
+$y_p=Ax^2e^x+Bx^3+Cx^2+D\cos x+E\sin x$ 
+}
+
+\begin{exercise}
+\pagebreak[2]
+\leavevmode
+\begin{tasks}
+\task Using variation of parameters find a particular solution of
+$y''-2y'+y = e^x$.
+\task Find a particular solution using undetermined
+coefficients.
+\task Are the two solutions you found the same?
+See also \exerciseref{exercise:diffvarparunder}.
+\end{tasks}
+\end{exercise}
+\exsolution{%
+a) The complementary solution is $y_c=C_1e^x+C_2xe^x$. Using 
+\begin{align*}
+u_1'y_1+u_2'y_2 &=0 \\
+u_1'e^x+u_2'xe^x &=0 \rightarrow u_1'=-xu_2'\\ 
+\end{align*}
+And using 
+\begin{align*}
+u_1'y_1'+u_2'y_2' &= f(x)\\
+u_1'e^x+u_2'(xe^x+e^x)& = e^x \rightarrow u_2'=1 \\
+\textrm{integrating}\ & \rightarrow u_2=x,\ u_1=-\frac{x^2}{2}
+\end{align*}
+The particular solution is 
+\begin{align*}
+y_p &=u_1y_1+u_2y_2 \\
+&= -\frac{x^2}{2}e^x+x^2e^x=\frac{x^2e^x}{2}
+\end{align*}
+\\
+b) We guess the particular solution has the form $y_p=Ae^x$, which is duplicated in $y_c$, so we multiply by $x^2$ giving 
+\begin{align*}
+y_p &=Ax^2e^x \\
+y_p'&= Ax^2e^x+2Axe^x \\
+y_p'' &= Ax^2e^x+4Axe^x+2Ae^x
+\end{align*}
+Plugging into the ODE we find that $A=1/2$, so 
+\begin{align*}
+y_p=\frac{x^2e^x}{2}
+\end{align*}
+As found in (a).
+\\
+c) Yes, the answers match!
+}
+
+\begin{exercise}
 Use variation of parameters to
 find a particular solution of $y''-y = \frac{1}{e^x+e^{-x}}$.
 \end{exercise}
@@ -2502,11 +2931,102 @@ $y = \frac{2xe^x-(e^x+e^{-x})\log(e^{2x}+1)}{4}$
 }
 
 \begin{exercise}
+Find a particular solution of
+$y''-2y' +y = \sin (x^2)$.  It is OK to leave the answer as a definite
+integral.
+\end{exercise}
+\exsol{%
+$y_p=e^x\int \frac{\sin(x^2)}{e^x}dx-xe^x\int \frac{x\sin(x^2)}{e^x}dx$
+}
+
+\begin{exercise}
+For an arbitrary constant $c$ find a particular solution
+to $y''-y=e^{cx}$.  Hint: Make sure to handle every possible real $c$.
+\end{exercise}
+\exsolution{%
+The complementary solution is $y_c=C_1e^x+C_2e^{-x}$. So we guess a particular solution of the form $y_p=Ae^{cx}$. We look at the case where $c=\pm1$ (case 1). Here we have
+\begin{align*}
+y_p &=Axe^{cx} \\
+y_p' &=cAxe^{cx}+Ae^{cx} \\
+y_p'' &=c^2Axe^{cx}+2cAe^{cx}
+\end{align*}
+Plugging into the ODE
+\begin{align*}
+c^2Axe^{cx}+2cAe^{cx}-Axe^{cx}=e^{cx}
+\end{align*}
+Since $c=\pm 1$ this simplifies to 
+\begin{align*}
+2cA &=1 \rightarrow \\
+A&=1/2,\ \textrm{for}\ c=1 \\
+A&=-1/2,\ \textrm{for}\ c=-1
+\end{align*}
+In the case where $c\neq \pm1$ (case 2), no modification is needed for our guess. Repeating the same process as above we find that 
+\begin{align*}
+A=\frac{1}{c^2-1}
+\end{align*}
+So finally the particular solution is
+\begin{align*}
+y_p=
+\begin{cases}
+\frac{xe^x}{2},\quad c=1 \\
+-\frac{xe^{-x}}{2},\quad c=-1 \\
+\frac{e^{cx}}{c^2-1},\quad \textrm{otherwise}
+\end{cases}
+\end{align*}
+}
+
+\begin{exercise}
 For an arbitrary constant $c$ find the general solution
 to $y''-2y=\sin(x+c)$.
 \end{exercise}
 \exsol{%
 $y=\frac{-\sin(x+c)}{3}+C_1 e^{\sqrt{2}\,x}+C_2 e^{-\sqrt{2}\,x}$
+}
+
+\begin{exercise} \label{exercise:diffvarparunder}
+\pagebreak[2]
+\leavevmode
+\begin{tasks}
+\task Using variation of parameters find a particular solution of
+$y''-y = e^x$.
+\task Find a particular solution using undetermined
+coefficients.
+\task Are the two solutions you found the same?
+What is going on?
+\end{tasks}
+\end{exercise}
+\exsol{%
+a) Using variation of parameters, we find $u_1=\frac{x}{2}$ and $u_2=-\frac{e^{2x}}{4}$ giving $y_p=\frac{x}{2}e^x-\frac{e^x}{4}$. \\
+b) Using undetermined coefficients we guess $y_p=Axe^x$ where $A=1/2$, giving $y_p=\frac{xe^x}{2}$. \\
+c) It is acceptable to get different $y_p$ with different methods. What needs to remain the same is the general solution (or the solution to the initial value problem). Looking at the general solution from (b)
+\begin{align*}
+y=C_1e^x+C_2e^{-x}+\frac{xe^x}{2}
+\end{align*}
+And the general solution from (a)
+\begin{align*}
+y &=C_1e^x+C_2e^{-x}+\frac{xe^x}{2}-\frac{e^x}{4} \\
+&= (\underbrace{C_1-\frac{1}{4}}_{\textrm{call}\ C_3})e^x++C_2e^{-x}+\frac{xe^x}{2} \\
+y &= C_3e^x+C_2e^{-x}+\frac{xe^x}{2}
+\end{align*}
+So the general solution is the same in both cases, as it should be. 
+}
+
+\begin{exercise}
+Find a polynomial $P(x)$, so that
+$y = 2 x^2 + 3 x + 4$
+solves
+$y''+5 y'+ y = P(x)$.
+\end{exercise}
+\exsolution{%
+Finding $y'$ and $y''$
+\begin{align*}
+y' &=4x+3 \\
+y'' &= 4
+\end{align*}
+We plug this into the ODE, giving 
+\begin{align*}
+P(x)=2x^2+23x+23
+\end{align*}
 }
 
 \begin{exercise}
@@ -2952,12 +3472,57 @@ back to this section once we have learned about the Fourier series.
 Derive a formula for $x_{sp}$ if the equation is
 $m x'' + c x' + kx = F_0 \sin (\omega t)$.  Assume $c > 0$.
 \end{exercise}
+\exsolution{%
+We know that in such a case, the particular solution should look like $x_{sp}=A\cos(\omega t)+B\sin(\omega t)$. So differentiating this and plugging it into the ODE we get
+\begin{align*}
+\left((\omega_0^2-\omega^2)B-2\omega pA\right)\sin(\omega t)+\left((\omega_0^2-\omega^2)A+2\omega pB\right)\cos(\omega t)=\frac{F_0}{m}\sin(\omega t)
+\end{align*}
+Where $\omega_0$ and $p$ are defined as before. Solving for $A$ and $B$ we get
+\begin{align*}
+&A=\frac{-F_0(2\omega p)}{m(2\omega p)^2+m(\omega_0^2-\omega^2)^2},\quad B=\frac{(\omega_0^2-\omega^2)^2F_0}{m(2\omega p)^2+m(\omega_0^2-\omega^2)^2} \\
+& C=\sqrt{A^2+B^2}=\frac{F_0}{m\sqrt{(2\omega p)^2+(\omega_0^2-\omega^2)^2}} \\
+& \tan(\gamma)=\frac{B}{A}=-\frac{\omega_0^2-\omega^2}{2\omega p}
+\end{align*}
+Therefore
+\begin{align*}
+x_{sp}=\frac{F_0}{m\sqrt{(2\omega p)^2+(\omega_0^2-\omega^2)^2}}\cos(\omega t-\gamma)
+\end{align*}
+Note that only the phase shift changes (which makes sense given that the force also only changed by a phase shift). 
+}
 
 \begin{exercise}
 Derive a formula for $x_{sp}$ if the equation is
 $m x'' + c x' + kx = F_0 \cos (\omega t) + F_1 \cos (3\omega t)$.
 Assume $c > 0$.
 \end{exercise}
+\exsol{%
+We find $x_{sp}$ for each term on the right hand side.
+\begin{align*}
+x_{sp_0}=\frac{F_0}{m\sqrt{(2\omega p)^2+(\omega_0^2-\omega^2)^2}}\cos(\omega t-\gamma),\quad \tan \gamma_0=\frac{2\omega p}{\omega_0^2-\omega^2}
+\end{align*}
+And 
+\begin{align*}
+x_{sp_1}=\frac{F_0}{m\sqrt{(2(3\omega)p)^2+(\omega_0^2-(3\omega)^2)^2}}\cos(3\omega t-\gamma_1),\quad \tan \gamma_1=\frac{2(3\omega)p}{\omega_0^2-(3\omega)^2}
+\end{align*}
+So finally $x_{sp}=x_{sp_0}+x_{sp_1}$.
+}
+
+
+\begin{exercise}
+Derive a formula for $x_{sp}$ for
+$mx''+cx'+kx = F_0 \cos(\omega t) + A$,
+where $A$ is some constant.  Assume $c > 0$.
+\end{exercise}
+\exsol{%
+$x_{sp} = 
+\frac{(\omega_0^2-\omega^2) F_0}
+{m{(2\omega p)}^2+m{(\omega_0^2-\omega^2)}^2} \cos (\omega t) +
+\frac{2 \omega p F_0}
+{m{(2\omega p)}^2+m{(\omega_0^2-\omega^2)}^2} \sin (\omega t)
++ \frac{A}{k}$,
+where
+$p = \frac{c}{2m}$ and $\omega_0 = \sqrt{\frac{k}{m}}$.
+}
 
 \begin{exercise}
 Take $m x'' + c x' + kx = F_0 \cos (\omega t)$.
@@ -2966,6 +3531,13 @@ For what values of $c$ (solve in terms of $m$, $k$, and $F_0$) will there be no
 practical resonance (that is, for what values of $c$ is there no maximum of
 $C(\omega)$ for $\omega > 0$)?
 \end{exercise}
+\exsolution{%
+There is no practical resonance if $\omega_0^2-2p^2\leq 0$ so
+\begin{align*}
+(\frac{k}{m})-\frac{c^2}{2m^2}& \leq 0 \\
+c \geq \sqrt{2km}
+\end{align*}
+}
 
 \begin{exercise}
 Take $m x'' + c x' + kx = F_0 \cos (\omega t)$.
@@ -2974,6 +3546,20 @@ For what values of $m$ (solve in terms of $c$, $k$, and $F_0$) will there be no
 practical resonance (that is, for what values of $m$ is there no maximum of
 $C(\omega)$ for $\omega > 0$)?
 \end{exercise}
+\exsol{%
+As was done in the previous exercise, we find $m \leq \frac{c^2}{2k}$. 
+}
+
+\begin{exercise}
+A mass of \unit[4]{kg} on a spring with $k=\unitfrac[4]{N}{m}$ and a damping
+constant $c=\unitfrac[1]{Ns}{m}$.
+Suppose that $F_0 = \unit[2]{N}$.  Using forcing function $F_0 \cos (\omega t)$,
+find the $\omega$ that causes practical resonance and find the amplitude.
+\end{exercise}
+\exsol{%
+$\omega = \frac{\sqrt{31}}{4\sqrt{2}} \approx 0.984$ \quad
+$C(\omega) = \frac{16}{3\sqrt{7}} \approx 2.016$
+}
 
 \begin{exercise}
 \pagebreak[3]
@@ -3003,36 +3589,36 @@ tower moves more than 1.5 meter from the rest position, the tower collapses.
 Will the tower collapse?
 \end{tasks}
 \end{exercise}
-
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-A mass of \unit[4]{kg} on a spring with $k=\unitfrac[4]{N}{m}$ and a damping
-constant $c=\unitfrac[1]{Ns}{m}$.
-Suppose that $F_0 = \unit[2]{N}$.  Using forcing function $F_0 \cos (\omega t)$,
-find the $\omega$ that causes practical resonance and find the amplitude.
-\end{exercise}
-\exsol{%
-$\omega = \frac{\sqrt{31}}{4\sqrt{2}} \approx 0.984$ \quad
-$C(\omega) = \frac{16}{3\sqrt{7}} \approx 2.016$
+\exsolution{%
+No friction means that $c=0$, and the differential equation is
+\begin{align*}
+x''+\omega_0^2x=\frac{F_0}{m}\cos(\omega t)
+\end{align*}
+The initial conditions are $x(0)=0,\ x'(0)=0$, and the applied force is $F(t)=F_0\cos(\omega t),\ F_0=mA\omega^2$.
+\\
+a) $\omega_0=\sqrt{k/m}=\sqrt{1/10}$.
+\\
+b) For undamped, forced motion with $\omega\neq \omega_0$ we know that
+\begin{align*}
+x(t)=C_1\cos(\omega_0 t)+C_2\sin(\omega_0 t)+\frac{A\omega^2}{(\omega_0^2-\omega^2)}\cos(\omega t)
+\end{align*}
+Applying the initial conditions, we find that 
+\begin{align*}
+C_1=\frac{-A\omega^2}{\omega_0^2-\omega^2},\quad C_2=0
+\end{align*}
+Giving
+\begin{align*}
+x&=\frac{A\omega^2}{\omega_0^2-\omega}\left(\cos(\omega t)-\cos(\omega_0 t)\right) \\
+&= \underbrace{\frac{2A\omega^2}{\omega_0^2-\omega}}_{C(\omega)} \sin\left( \frac{\omega+\omega_0}{2}t\right)\sin\left( \frac{\omega-\omega_0}{2}t\right)
+\end{align*}
+\\
+c) Plugging the given values into the answer from (b), we find 
+\begin{align*}
+C(\omega)=\frac{2\times 1\times \pi^2}{\pi^2-0.1^2}\approx 2\ \textrm{m}
+\end{align*}
+So the tower collapses.
 }
 
-\begin{exercise}
-Derive a formula for $x_{sp}$ for
-$mx''+cx'+kx = F_0 \cos(\omega t) + A$,
-where $A$ is some constant.  Assume $c > 0$.
-\end{exercise}
-\exsol{%
-$x_{sp} = 
-\frac{(\omega_0^2-\omega^2) F_0}
-{m{(2\omega p)}^2+m{(\omega_0^2-\omega^2)}^2} \cos (\omega t) +
-\frac{2 \omega p F_0}
-{m{(2\omega p)}^2+m{(\omega_0^2-\omega^2)}^2} \sin (\omega t)
-+ \frac{A}{k}$,
-where
-$p = \frac{c}{2m}$ and $\omega_0 = \sqrt{\frac{k}{m}}$.
-}
 
 \begin{exercise}
 Suppose there is no damping in a mass and spring system with

--- a/ch-higher-order-ode.tex
+++ b/ch-higher-order-ode.tex
@@ -5,9 +5,9 @@
 \section{Second order linear ODEs}
 \label{solinear:section}
 
-\sectionnotes{1 lecture, reduction of order optional\EPref{,
-first part of \S3.1 in \cite{EP}}\BDref{,
-parts of \S3.1 and \S3.2 in \cite{BD}}}
+\begin{video}[1w5u-JgBc1w][2nd Order Linear Equations][secondorder]
+  We now move to 2nd order ODEs. We shall begin with 2nd order linear ODEs which are much easier to handle than nonlinear ODEs. Some of the theory, like Existence and Uniqueness parallel the 1st order case pretty well. However, we shall see that there are some new complications like Superposition to think about and we are going to have a lot of parallels to linear algebra here. 
+\end{video}
 
 Let us consider the general
 \emph{\myindex{second order linear differential equation}}
@@ -387,11 +387,14 @@ $y''-3y'+2y = 0$
 \section{Constant coefficient second order linear ODEs}
 \label{sec:ccsol}
 
-\sectionnotes{more than 1 lecture\EPref{,
-second part of \S3.1 in \cite{EP}}\BDref{,
-\S3.1 in \cite{BD}}}
+
 
 \subsection{Solving constant coefficient equations}
+
+
+\begin{video}[4ldFfny-RlE][Constant Coefficients (Distinct Roots)][constantcoefficients]
+  We now move to 2nd order ODEs. We shall begin with 2nd order linear ODEs which are much easier to handle than nonlinear ODEs. Some of the theory, like Existence and Uniqueness parallel the 1st order case pretty well. However, we shall see that there are some new complications like Superposition to think about and we are going to have a lot of parallels to linear algebra here. 
+\end{video}
 
 Consider the problem
 \begin{equation*}
@@ -453,6 +456,12 @@ y = -7 e^{2x} + 5 e^{4x} .
 \end{equation*}
 
 \medskip
+
+\begin{video}[H8dYb9rJ36Y][The Constant Coefficient Method (all cases)][constantcoefficients2]
+  In this video we generalize ad categorize all the possibilities for a 2nd order homogeneous constant coefficient equation
+\end{video}
+
+
 
 Let us generalize this example into a method.
 Suppose that we have an equation
@@ -895,16 +904,6 @@ $y'' -y'-6y=0$
 \sectionnewpage
 \section{Higher order linear ODEs} \label{sec:hol}
 
-\sectionnotes{somewhat more than 1 lecture\EPref{, \S3.2 and \S3.3 in
-\cite{EP}}\BDref{,
-\S4.1 and \S4.2 in \cite{BD}}}
-
-%After reading this lecture, it may be good to try
-%Project III\index{IODE software!Project III} from the
-%IODE website: \url{http://www.math.uiuc.edu/iode/}.
-%
-%\medskip
-
 We briefly study higher order equations.
 Equations appearing in applications tend to be second
 order.  Higher order equations do appear from time to time, but
@@ -927,39 +926,13 @@ Let us start with a general homogeneous linear equation
 y^{(n)} + p_{n-1}(x)y^{(n-1)} + \cdots + p_1(x) y' + p_0(x) y = 0 .
 \end{equation}
 
-\begin{theorem}[Superposition]\index{superposition}
-Suppose $y_1$, $y_2$, \ldots, $y_n$ are solutions of the
-homogeneous equation \eqref{hol:eqlinhom}.  Then 
-\begin{equation*}
-y(x) = C_1 y_1(x) + C_2 y_2(x) + \cdots + C_n y_n(x) 
-\end{equation*}
-also solves \eqref{hol:eqlinhom}
-for arbitrary constants $C_1, C_2, \ldots, C_n$.
-\end{theorem}
-
-In other words, a \emph{\myindex{linear combination}} of solutions
-to \eqref{hol:eqlinhom}
-is also a solution to \eqref{hol:eqlinhom}.
-We also have the existence and uniqueness theorem for nonhomogeneous linear
-equations.
-
-\begin{theorem}[Existence and uniqueness]\index{existence and uniqueness}
-Suppose $p_0$ through $p_{n-1}$, and $f$ are continuous functions
-on some interval $I$,
-$a$ is a number in $I$,
-and $b_0, b_1, \ldots, b_{n-1}$ are constants.
-The equation
-\begin{equation*} %\label{hol:eqlin}
-y^{(n)} + p_{n-1}(x)y^{(n-1)} + \cdots + p_1(x) y' + p_0(x) y = f(x) 
-\end{equation*}
-has exactly one solution $y(x)$ defined on the same interval $I$
-satisfying the initial conditions
-\begin{equation*}
-y(a) = b_0, \quad y'(a) = b_1, \quad \ldots, \quad y^{(n-1)}(a) = b_{n-1} .
-\end{equation*}
-\end{theorem}
-
 \subsection{Linear independence}
+
+\begin{video}[RDp9Tg7gj5U][Linear Independence][higherlinear]
+  We briefly saw the idea of two functions being linearly independent when talking about the theory of 2nd order ODEs in \sectionref{solinear:section}. Now that we are talking about nth order, we need to figure out how to show that n functions are linearly independent. As you can imagine there are strong parallels to linear algebra, but we also get something unique to ODEs called the Wronskian which will be a test for linear independence.
+\emph{Note: While the Wronskian was covered by Bazett in the videos of this section, the text of this section written by Lebl avoids this topic.}
+\end{video}
+
 
 When we had two functions $y_1$ and $y_2$ we said they were linearly
 independent if one was not the multiple of the other.  Same idea holds for
@@ -1053,7 +1026,52 @@ dependent.  Simply apply definition of the hyperbolic cosine:
 \end{equation*}
 \end{example}
 
+\subsection{Theory of Higher Order ODEs}
+
+\begin{video}[4ofQRpaI9ko][Theory of Higher Order ODEs][highertheory]
+  In this video we put on a firmer ground the theory of higher order ODEs. This both is what really makes the method of constant coefficients work for higher order cases, but these theorems also apply to more general linear ODEs.
+\end{video}
+
+
+\begin{theorem}[Superposition]\index{superposition}
+Suppose $y_1$, $y_2$, \ldots, $y_n$ are solutions of the
+homogeneous equation \eqref{hol:eqlinhom}.  Then 
+\begin{equation*}
+y(x) = C_1 y_1(x) + C_2 y_2(x) + \cdots + C_n y_n(x) 
+\end{equation*}
+also solves \eqref{hol:eqlinhom}
+for arbitrary constants $C_1, C_2, \ldots, C_n$.
+\end{theorem}
+
+In other words, a \emph{\myindex{linear combination}} of solutions
+to \eqref{hol:eqlinhom}
+is also a solution to \eqref{hol:eqlinhom}.
+We also have the existence and uniqueness theorem for nonhomogeneous linear
+equations.
+
+\begin{theorem}[Existence and uniqueness]\index{existence and uniqueness}
+Suppose $p_0$ through $p_{n-1}$, and $f$ are continuous functions
+on some interval $I$,
+$a$ is a number in $I$,
+and $b_0, b_1, \ldots, b_{n-1}$ are constants.
+The equation
+\begin{equation*} %\label{hol:eqlin}
+y^{(n)} + p_{n-1}(x)y^{(n-1)} + \cdots + p_1(x) y' + p_0(x) y = f(x) 
+\end{equation*}
+has exactly one solution $y(x)$ defined on the same interval $I$
+satisfying the initial conditions
+\begin{equation*}
+y(a) = b_0, \quad y'(a) = b_1, \quad \ldots, \quad y^{(n-1)}(a) = b_{n-1} .
+\end{equation*}
+\end{theorem}
+
+
+
 \subsection{Constant coefficient higher order ODEs}
+
+\begin{video}[IwM3JlNPlgQ][Higher Order Constant Coefficient ODEs][higherorderconstant]
+  Let's consider the generalization of the constant coefficient method to higher order. A few things change. Our characteristic equation is now an nth order polynomial, which we can still factor, although this can be harder than just using the quadratic formula, and we get a range of options analogous to the 2D case. 
+\end{video}
 
 When we have a higher order constant coefficient homogeneous linear
 equation, the song and dance is exactly the same as it was for second order.
@@ -1353,13 +1371,12 @@ $y'''-y''+y'-y=0$
 \sectionnewpage
 \section{Mechanical vibrations} \label{sec:mv}
 
-\sectionnotes{2 lectures\EPref{, \S3.4 in \cite{EP}}\BDref{,
-\S3.7 in \cite{BD}}}
-
 Let us look at some applications of linear second order constant
 coefficient equations.
 
 \subsection{Some examples}
+
+
 
 \begin{mywrapfigsimp}{2.0in}{2.3in}
 \noindent
@@ -1487,6 +1504,12 @@ the physics of the situation to see if the simplification is valid in the
 context of the questions we are trying to answer.
 
 \subsection{Free undamped motion}
+
+\begin{video}[pGXLxgdiRHQ][Frictionless Mechanical Vibrations][undampedmechanical]
+  In this video we imagine a mass moving due to the force of a spring in a frictionless environment, what is often called a harmonic oscillator. From the perspective of ODEs, this is just a 2nd order constant coefficient homogeneous ODE. However we also need to physically interpret the results that we get. 
+\emph{TYPO: My characteristic equation at 3:06 should be +k not -k. I did the subsequent finding the roots correctly, the minus sign error was just in the characteristic equation. }
+
+\end{video}
 
 In this section we only consider free or unforced motion,
 as we do not know yet how to solve nonhomogeneous equations.  Let us start with
@@ -1628,6 +1651,10 @@ takes two arguments, $B$ and $A$, and returns a $\gamma$ in the
 correct quadrant for you.
 
 \subsection{Free damped motion}
+
+\begin{video}[SMHC3Khm6cg][Damped Mechanical Vibrations][dampedmechanical]
+  We can also study a mass-spring system that has a damping or friction force proportional to velocity. Again it is a constant coefficient 2nd order ODE, but now we get quite a bit more complexity in the possible solutions depending on the values of coefficients. 
+\end{video}
 
 %mbxINTROSUBSUBSECTION
 
@@ -1943,10 +1970,11 @@ not oscillate.
 \section{Nonhomogeneous equations}
 \label{sec:nonhom}
 
-\sectionnotes{2 lectures\EPref{, \S3.5 in \cite{EP}}\BDref{,
-\S3.5 and \S3.6 in \cite{BD}}}
-
 \subsection{Solving nonhomogeneous equations}
+
+\begin{video}[_5aKZh7_71Q][Solving Nonhomogeneous Equatios using Undetermined Coefficients][undeterminedcoefficients]
+  Our study of constant coefficient ODEs thus far has always had them be homogeneous, that is no terms only in the independent variable. How can we deal with a non-homogeneity? In this video we learn the Method of Undetermined Coefficients. We first learn a bit of theory that lets us relate solutions to the non-homogeneous equation to solutions of the corresponding homogeneous equation, and then the methodology is basically a bit of intelligent guessing to find a solution that works. 
+\end{video}
 
 We have solved linear constant coefficient homogeneous 
 equations.

--- a/ch-higher-order-ode.tex
+++ b/ch-higher-order-ode.tex
@@ -373,7 +373,7 @@ $r$.
 \exsol{%
 (a) $y=c_1x^{r_1}+c_2x^{r_2}$ where
 \begin{equation*}
-r_1=\frac{-(b-1)+\sqrt{(b-a)^2-4ac}}{2a},\quad r_2=\frac{-(b-1)-\sqrt{(b-a)^2-4ac}}{2a}
+r_1=\frac{-(b-a)+\sqrt{(b-a)^2-4ac}}{2a},\quad r_2=\frac{-(b-a)-\sqrt{(b-a)^2-4ac}}{2a}
 \end{equation*}
 Where $r_1$ and $r_2$ are real and distinct, since $(b-a)^2-4ac >0$ under the square root.  \\
 (b) If equal to 0, then $r_1=r_2=r$. We would need to find another linearly independent solution since the two terms in the solution in part (a) become linearly dependent now. \\
@@ -763,6 +763,8 @@ Often the following notation is used,
 \operatorname{Im}(a+ib) = b.
 \end{equation*}
 
+
+
 \subsection{Complex roots}
 
 Suppose the equation $ay'' + by' + cy = 0$ has the 
@@ -1120,7 +1122,7 @@ y^{(n)} + p_{n-1}(x)y^{(n-1)} + \cdots + p_1(x) y' + p_0(x) y = 0 .
 
 \begin{video}[RDp9Tg7gj5U][Linear Independence][higherlinear]
   We briefly saw the idea of two functions being linearly independent when talking about the theory of 2nd order ODEs in \sectionref{solinear:section}. Now that we are talking about nth order, we need to figure out how to show that n functions are linearly independent. As you can imagine there are strong parallels to linear algebra, but we also get something unique to ODEs called the Wronskian which will be a test for linear independence.
-\emph{Note: While the Wronskian was covered by Bazett in the videos of this section, the text of this section written by Lebl avoids this topic.}
+\emph{Note: While the Wronskian was covered by Bazett in the videos of this section, the text of this section beyond a brief mention largely avoids this topic.}
 \end{video}
 
 
@@ -1139,13 +1141,34 @@ can solve for $y_1$ as a linear combination of the others.  If the functions
 are not
 linearly independent, they are \emph{\myindex{linearly dependent}}.
 
+There are several ways to show that a set of functions are linearly independent. The first method we'll present uses a tool called the Wronskian, which is rather unintuitive but computationally simple. 
+
+\begin{equation}
+W(y_1,...y_n)=
+\begin{vmatrix} 
+  y_1 & y_2 & ... & y_n \\
+  y_1' & y_2' & ... & y_n' \\ 
+  \vdots  &  \vdots &  \vdots &  \vdots \\
+  y_1^{(n-1)} & y_2^{(n-1)} & ... & y_n^{(n-1) }
+\end{vmatrix}
+.
+\end{equation}
+
+If the functions $y_1,...,y_n$ where linearly dependent (and $n-1$ times differentiable), then the columns of the matrix in the Wronskian will be as well and thus the Wronskian is zero. Thus to show a set of functions is linearly independent on an interval $I$ it suffices to find a single point in $I$ where the Wronskian is non-zero. Note the converse is not true, $W=0$ does not imply linear dependence. 
+
+\begin{example}
+  $e^x$ and $e^{2x}$ are linearly independent as 
+  \begin{equation*}
+    W(e^x, e^{2x})=\begin{vmatrix}e^x & e^{2x}\\
+      e^x & 2e^{2x}\end{vmatrix}=e^{3x}.
+  \end{equation*}
+  As $e^{3x}\neq 0$ for any $x$, these two functions are linearly independent everywhere.
+\end{example}
+
 \begin{example}
 Show that $e^x, e^{2x}, e^{3x}$ are linearly independent.
 
-Let us give several ways to show this fact.
-Many textbooks (including \cite{EP} and
-\cite{F}) introduce Wronskians, but it is difficult to see why they work and
-they are not really necessary here.
+
 
 Let us write down
 \begin{equation*}
@@ -1427,7 +1450,7 @@ Find the general solution for $y''' - y'' + y' - y = 0$.
 \exsolution{%
 The characteristic equation is
 \begin{align*}
-r^3-r^2+3-1 &=0 \\
+r^3-r^2+r-1 &=0 \\
 (r^2+1)(r-1) &=0\quad \rightarrow r_1=1,\ r_2=i,\ r_3=-i
 \end{align*}
 Therefore the general solution is
@@ -1953,6 +1976,15 @@ This function
 takes two arguments, $B$ and $A$, and returns a $\gamma$ in the
 correct quadrant for you.
 
+
+\begin{example}
+  \emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/wcgwfrtg}{this Geogebra applet} to to explore the effects of the mass $m$, spring constant $k$, and the initial conditions $x(0)=A$, $x'(0)=B$ on the solution of the free undamped equation $mx''+kx=0$.
+  
+
+
+
+  \end{example}
+
 \subsection{Free damped motion}
 
 \begin{video}[SMHC3Khm6cg][Damped Mechanical Vibrations][dampedmechanical]
@@ -2137,6 +2169,15 @@ On the other hand, when $c$ gets smaller, $\omega_1$ approaches $\omega_0$
 periodic motion of the undamped case.  The envelope curves become flatter and
 flatter as $c$ (and hence $p$) goes to 0.
 
+
+\begin{example}
+  \emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/nhsahq8e}{this Geogebra applet} to explore the behaviour of a free damped system as you change the parameters $k, m, c, x_0$ and $v_0$. 
+  
+
+
+
+  \end{example}
+
 \subsection{Exercises}
 
 \begin{exercise}
@@ -2201,7 +2242,7 @@ r &= -\frac{1}{4}\pm i\frac{\sqrt{23}}{4}
 \end{align*} 
 So the general solution is 
 \begin{align*}
-x(t)=e^{-x/4}\left[C_1\cos(\frac{\sqrt{23}}{4}x)+C_2\sin(\frac{\sqrt{23}}{4}x)\right]
+x(t)=e^{-t/4}\left[C_1\cos(\frac{\sqrt{23}}{4}t)+C_2\sin(\frac{\sqrt{23}}{4}t)\right]
 \end{align*}
 \\
 b) From the general solution (complex roots), the system is underdamped. 
@@ -2718,20 +2759,36 @@ $f(x) = u_1' y_1' + u_2' y_2'$.
 
 What we need to solve are the two equations (conditions) we imposed
 on $u_1$ and $u_2$:
-\begin{equation*}
+\begin{equation}
 \mybxbg{~~
 \begin{aligned}
 & u_1' y_1 + u_2' y_2 = 0 ,\\
 & u_1' y_1' + u_2' y_2' = f(x) .
 \end{aligned}
 ~~}
-\end{equation*}
-We solve for $u_1'$ and $u_2'$ in terms of $f(x)$, $y_1$ and $y_2$.
+\end{equation}
 We always get these formulas for any $Ly = f(x)$, where $Ly =
-y''+p(x)y'+q(x)y$.  There is a general
-formula for the solution we could just plug into, but instead of memorizing
-that, it is better, and easier, to
-just repeat what we do below.  In our case the two equations are
+y''+p(x)y'+q(x)y$.  Now we solve for $u_1'$ and $u_2'$ in terms of $f(x)$, $y_1$ and $y_2$ giving
+\begin{equation*}
+u_1(t)=-\int_{t_0}^t\frac{y_2(s)f(s)}{W(y_1,y_2)(s)}ds,
+\end{equation*}
+\begin{equation*}
+  u_2(t)=\int_{t_0}^t\frac{y_1(s)f(s)}{W(y_1,y_2)(s)}ds,
+\end{equation*}
+
+where $W(y_1,y_2)(s)=y_1(s)y_2'(s)-y_2(s)y_1'(s)$ is the Wronskian of $y_1$ and $y_2$ at a point $s$. This gives us the general formula 
+
+\begin{equation}
+  \mybxbg{~~
+y=-y_1(t)\int_{t_0}^t\frac{y_2(s)f(s)}{W(y_1,y_2)(s)}ds+y_2(t)\int_{t_0}^t\frac{y_1(s)f(s)}{W(y_1,y_2)(s)}ds
+  ~~}
+  \end{equation}
+
+
+
+We could just plug into this general formula, but memorizing this complicated formula is tedious and not instructive so and instead one can ignore the above formula and just go through the process to derive the formula in each specific case. Let's do that now for our example with $f(x)=\tan(x)$.  
+
+In our case the two equations are
 \begin{align*}
 u_1' \cos (x) + u_2' \sin (x) &= 0 ,\\
 -u_1' \sin (x) + u_2' \cos (x) &= \tan (x) .
@@ -3465,6 +3522,14 @@ A general periodic function will be the sum (superposition) of many
 cosine waves of different frequencies.
 The reader is encouraged to come
 back to this section once we have learned about the Fourier series.
+
+\begin{example}
+  \emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/nhsahq8e}{this Geogebra applet} to explore the behaviour of a forced damped harmonic oscillator. Try to find the practical resonance for some choice of parameters.
+  
+
+
+
+  \end{example}
 
 \subsection{Exercises}
 

--- a/ch-intro.tex
+++ b/ch-intro.tex
@@ -9,12 +9,36 @@
 \section{Notes about these notes}
 \label{notes:section}
 
-This version of the textbook is for the Ordinary Differential Equations portion of Math 204 at the Univesrity of Victoria. This version is a fork with adaption by Trefor Bazett of the original text by Jiří Lebl. If you are an instructor,  \href{https://www.jirka.org/diffyqs/html/notes_section.html}{please consult the original version of the text} for more information and potential uses.
+This version of the textbook is for the Ordinary Differential Equations portion of Math 204 at the University of Victoria. This version is a fork adapted by Trefor Bazett of the original text by Jiří Lebl.
+
+\subsection{Original Textbook by Jiří Lebl}
+
+The original version of the textbook by  Jiří Lebl comes in three forms:
+
+\begin{enumerate}
+    \item \href{https://www.jirka.org/diffyqs/html/diffyqs.html}{The Web Version}.
+    \item \href{https://www.jirka.org/diffyqs/diffyqs.pdf}{A PDF}.
+    \item \href{https://smile.amazon.com/dp/1706230230\}{A printed paperback on Amazon }.
+    \end{enumerate}
+
+Additionally, \href{https://www.jirka.org/diffyqs/}{Jiří Lebl's website for the book} contain's a lot of additional information including the source code. 
+
+Note that this forked version of the book for Math 204 at UVic is only available in web version. If you would prefer a .pdf or printed version, as of this writing the books are similar enough that you can certainly access the original .pdf or printed version with the above links. 
+
+If you are an instructor,  \href{https://www.jirka.org/diffyqs/html/notes_section.html}{please consult the original version of the text} for more information and potential uses.
+
+\subsection{Differences between the versions}
+As of this writing, the original text by Jiří Lebl and the forked version by Trefor Bazett are very similar. The most substantial changes in the forked version are embedding of a video series and an expansion of the exercises at the end of each section, with more questions, more answers, and some brif solutions. For a more precise comparison, please consult the respective github pages for the original and forked version. 
+
+
+\subsection{The video playlist}
+The full playlist of videos \href{https://www.youtube.com/playlist?list=PLQ9f-JfDG2WyBPsKFkkfszurhIYeKN6oX}{can be found here}, and consists of both Vector Calculus (not covered in this textbook) and ODEs (covering this textbook). The individual videos are embedded throughout the text. 
+
+The videos are intended to be complimentary to the textbook. You could learn the content just by reading the textbook, as in the original version by Lebl. The other direction is not true; the videos alone don't always
+cover all the content. Typically the videos use slightly different examples from the textbook so that you can get extra exposure by reading/watching both. While there was an effort for the notation and scope of the videos to be similar to the textbook, ultimately the book is largely written by Lebl and the videos recorded by Bazett and there are stylistic differences and differences in emphasis between these two. 
 
 
 
-
-%\medskip
 \subsection{Computer resources}
 
 The book's
@@ -36,20 +60,15 @@ works with Matlab (proprietary) or Octave (free software).
 %trouble running on newer versions of Matlab.
 The graphs in the book were made with
 the Genius\index{Genius software} software
-(see \url{https://www.jirka.org/genius.html}).  I use Genius
-in class to show these (and other) graphs.
+(see \url{https://www.jirka.org/genius.html}). 
 
-The \LaTeX\ source of the book is also available
-for possible modification and customization
-at github (\url{https://github.com/jirilebl/diffyqs}).
-
-%\medskip
-
-%\textbf{Acknowlegements:}
+The \LaTeX\ source is available on github for the original version by Lebl (\url{https://github.com/jirilebl/diffyqs}) as well as the forked version by Bazett (\url{https://github.com/tbazett/diffyqs}) for possible modification and customizations.
 
 \subsection{Acknowledgments}
 
-Acknowlegements by Trefor Bazett: Firstly, I want to thank the incredibly work of Ji\v{r}\'i Lebl for creating and maintaining this excellent textbook, without which this project would have been beyond daunting to begin. I want to thank both Afif Omar and Muhammad Awais for their extensive work on revising the exercises, answers, and solutions. This project is supported by an grant through the LTSI at the University of Victoria to create Open Educational Resources. 
+
+
+Acknowlegements by Trefor Bazett: Firstly, I want to thank the incredibly work of Ji\v{r}\'i Lebl for creating and maintaining this excellent textbook, without which this project would have been beyond daunting to begin. I want to thank both Afif Omar and Muhammad Awais for their extensive work on revising the exercises, answers, and solutions. This project is supported by a grant through the LTSI at the University of Victoria to create Open Educational Resources. 
 
 Acknowledgements by Ji\v{r}\'i Lebl: Firstly, I would like to acknowledge Rick Laugesen.  I used his handwritten
 class notes
@@ -101,10 +120,12 @@ to acknowledge NSF grants DMS-0900885 and DMS-1362337.
 \section{Introduction to differential equations}
 \label{introde:section}
 
-\sectionnotes{more than 1 lecture\EPref{, \S1.1 in \cite{EP}}\BDref{,
-chapter 1 in \cite{BD}}}
 
 \subsection{Differential equations}
+
+\begin{video}[KM3n22ZE8Bw][Intro to Differential Equations][introode]
+    In this video we will learn the big ideas of differential equations. We will specifically focus on two, the equation for exponential growth and for freefall of an object in gravity.   
+\end{video}
 
 The laws of physics are generally written down as differential
 equations.  Therefore, all of science and engineering use
@@ -117,6 +138,8 @@ language as far as science and engineering are concerned.  As an analogy,
 suppose all your classes from now on were given in Swahili.  
 It would be important to first learn Swahili, or you would have a very
 tough time getting a good grade in your classes.
+
+
 
 You saw many
 differential equations already without perhaps knowing about it.
@@ -136,6 +159,9 @@ equation arises from Newton's law of cooling where the ambient
 temperature oscillates with time.
 
 \subsection{Solutions of differential equations}
+
+\begin{video}[wtnwuHdPMAw][The Key Definitions of Differential Equations][keydefs]Let's be a bit more careful with the definitions and ideas introduced in the first video. Along the way we will see a few different types of differential equations. 
+\end{video}
 
 Solving the differential equation means finding $x$ in terms of $t$.  That
 is, we want to find a function of $t$, which we call $x$, such that when
@@ -632,9 +658,6 @@ d)~$T=3\sinh(2x)$
 \sectionnewpage
 \section{Classification of differential equations}
 \label{classification:section}
-
-%Perhaps no [EP] ref?
-\sectionnotes{less than 1 lecture or left as reading\BDref{, \S1.3 in \cite{BD}}}
 
 There are many types of differential equations, and we classify them into
 different categories based on their properties.  Let us quickly go over

--- a/ch-intro.tex
+++ b/ch-intro.tex
@@ -6,10 +6,10 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\section{Notes about these notes}
+\section{About this book}
 \label{notes:section}
 
-This version of the textbook is for the Ordinary Differential Equations portion of Math 204 at the University of Victoria. This version is a fork adapted by Trefor Bazett of the original text by Jiří Lebl.
+This version of the book is for the Ordinary Differential Equations portion of Math 204 at the University of Victoria. This version is a fork adapted by Trefor Bazett of the original text by Jiří Lebl.
 
 \subsection{Original Textbook by Jiří Lebl}
 
@@ -23,19 +23,20 @@ The original version of the textbook by  Jiří Lebl comes in three forms:
 
 Additionally, \href{https://www.jirka.org/diffyqs/}{Jiří Lebl's website for the book} contain's a lot of additional information including the source code. 
 
-Note that this forked version of the book for Math 204 at UVic is only available in web version. If you would prefer a .pdf or printed version, as of this writing the books are similar enough that you can certainly access the original .pdf or printed version with the above links. 
+Note that this forked version of the book for Math 204 at UVic is only available in web version. If you would prefer a .pdf or printed version, you can access the original .pdf or printed version with the above links. See the next section for differences between the versions.
 
 If you are an instructor,  \href{https://www.jirka.org/diffyqs/html/notes_section.html}{please consult the original version of the text} for more information and potential uses.
 
 \subsection{Differences between the versions}
-As of this writing, the original text by Jiří Lebl and the forked version by Trefor Bazett are very similar. The most substantial changes in the forked version are embedding of a video series and an expansion of the exercises at the end of each section, with more questions, more answers, and some brif solutions. For a more precise comparison, please consult the respective github pages for the original and forked version. 
+As of this writing, the original text by Jiří Lebl and the forked version by Trefor Bazett are very similar. The most substantial changes in the forked version are embedding of a video series by Trefor Bazett and an expansion of the exercises at the end of each section, with more questions, more answers, and some brief solutions. Additioally, there is a rearrangement of the content. For a more precise comparison, please consult the respective github pages for the original and forked version. 
 
+A few chapters in this book are not taught in Math 204, namely Systems, Non-Linear Systems, Eigenvalue Systems, and PDEs. These chapters remain for reference purposes in the forked version of the textbook entirely untouched by Trefor Bazett. 
 
 \subsection{The video playlist}
 The full playlist of videos \href{https://www.youtube.com/playlist?list=PLQ9f-JfDG2WyBPsKFkkfszurhIYeKN6oX}{can be found here}, and consists of both Vector Calculus (not covered in this textbook) and ODEs (covering this textbook). The individual videos are embedded throughout the text. 
 
 The videos are intended to be complimentary to the textbook. You could learn the content just by reading the textbook, as in the original version by Lebl. The other direction is not true; the videos alone don't always
-cover all the content. Typically the videos use slightly different examples from the textbook so that you can get extra exposure by reading/watching both. While there was an effort for the notation and scope of the videos to be similar to the textbook, ultimately the book is largely written by Lebl and the videos recorded by Bazett and there are stylistic differences and differences in emphasis between these two. 
+cover all the content. Typically the videos use slightly different examples from the textbook so that you can get extra exposure by reading/watching both. While there was an effort for the notation and scope of the videos to be similar to the textbook, ultimately the book is largely written by Lebl and the videos recorded by Bazett and there are stylistic differences and differences in emphasis between these two. Typically videos are placed immediately prior to the analogous text content covered in the video.
 
 
 
@@ -117,7 +118,7 @@ to acknowledge NSF grants DMS-0900885 and DMS-1362337.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \sectionnewpage
-\section{Introduction to differential equations}
+\section{What are Differential Equations?}
 \label{introde:section}
 
 
@@ -509,148 +510,189 @@ y = -127.7 \; \textrm{ft} \cdot \cosh({x / 127.7  \; \textrm{ft}}) + 757.7 \;
 \textrm{ft} .
 \end{equation*}
 
-
 \subsection{Exercises}
 
+
 \begin{exercise}
-Show that $x = e^{4t}$ is a solution to $x'''-12 x'' + 48 x' - 64 x = 0$.
+	Show that $x = e^{4t}$ is a solution to $x'''-12 x'' + 48 x' - 64 x = 0$.
 \end{exercise}
 
 \begin{exercise}
-Show that $x = e^{t}$ is not a solution to $x'''-12 x'' + 48 x' - 64 x = 0$.
+	Show that $x = e^{t}$ is not a solution to $x'''-12 x'' + 48 x' - 64 x = 0$.
 \end{exercise}
 
 \begin{exercise}
-Is $y = \sin t$ a solution to ${\left( \frac{dy}{dt} \right)}^2 = 1 - y^2$?
-Justify.
-\end{exercise}
-
-\begin{exercise}
-Let $y'' + 2y' - 8y = 0$.  Now try a solution of the form $y = e^{rx}$ for
-some (unknown) constant $r$.  Is this a solution
-for some $r$?  If so, find all such $r$.
-\end{exercise}
-
-\begin{exercise}
-Verify that $x = C e^{-2t}$ is a solution to $x' = -2x$.
-Find $C$ to solve for the initial condition $x(0) = 100$.
-\end{exercise}
-
-\begin{exercise}
-Verify that $x = C_1 e^{-t} + C_2 e^{2t}$ is a solution to $x'' - x' -2 x =
-0$.  Find $C_1$ and $C_2$ to solve for the initial conditions $x(0) = 10$
-and $x'(0) = 0$.
-\end{exercise}
-
-\begin{exercise}
-Find a solution to
-${(x')}^2 + x^2 = 4$
-using your knowledge of derivatives of functions that you
-know from basic calculus.
-\end{exercise}
-
-\begin{exercise}
-Solve:
-\begin{tasks}(2)
-\task $\dfrac{dA}{dt} = -10 A, \quad A(0)=5$
-\task $\dfrac{dH}{dx} = 3 H, \quad H(0)=1$
-\task $\dfrac{d^2y}{dx^2} = 4 y, \quad y(0)=0, \quad y'(0)=1$
-\task $\dfrac{d^2x}{dy^2} = -9 x, \quad x(0)=1, \quad x'(0)=0$
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-Is there a solution to $y' = y$, such that $y(0) = y(1)$?
-\end{exercise}
-
-\begin{exercise}
-The population of city X was 100 thousand 20 years ago, and 
-the population of city X was 120 thousand 10 years ago.  Assuming constant
-growth, you can use the exponential population model
-(like for the bacteria).  What do you estimate the population is now?
-\end{exercise}
-
-\begin{exercise}
-Suppose that a football coach gets a salary of
-one million dollars now, and a raise of $10\%$ every year
-(so exponential model, like population of bacteria).
-Let $s$ be the salary in millions of dollars, and $t$ is time in years.
-\begin{tasks}(2)
-\task
-What is $s(0)$ and $s(1)$.
-\task
-Approximately how many years will it take for the salary to be 10 million.
-\task
-Approximately how many years will it take for the salary to be 20 million.
-\task
-Approximately how many years will it take for the salary to be 30 million.
-\end{tasks}
-\end{exercise}
-
-
-%mbxSTARTIGNORE
-\noindent
-\emph{Note: Exercises with numbers 101 and higher have solutions in the
-back of the book.}
-%mbxENDIGNORE
-
-%mbx <p><em>Note: Exercises with numbers 101 and higher have solutions.</em></p>
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Show that $x = e^{-2t}$ is a solution to $x'' + 4x' + 4x = 0$.
+	Is $y = \sin t$ a solution to ${\left( \frac{dy}{dt} \right)}^2 = 1 - y^2$?
+	Justify.
 \end{exercise}
 \exsol{%
-Compute $x' = -2e^{-2t}$ and $x'' = 4e^{-2t}$.  Then
-$(4e^{-2t}) + 4 (-2e^{-2t}) + 4 (e^{-2t}) = 0$.
+Yes, since $\cos^2t=1-\sin^2t$ by a trig identity.
 }
 
 \begin{exercise}
-Is $y = x^2$ a solution to $x^2y'' - 2y = 0$?  Justify.
+	Let $y'' + 2y' - 8y = 0$.  Now try a solution of the form $y = e^{rx}$ for
+	some (unknown) constant $r$.  Is this a solution
+	for some $r$?  If so, find all such $r$.
 \end{exercise}
 \exsol{%
-Yes.
-}
-
-\begin{exercise}
-Let $xy'' - y' = 0$.  Try a solution of the form $y = x^r$.  Is this a
-solution for some $r$?  If so, find all such $r$.
-\end{exercise}
-\exsol{%
-$y=x^r$ is a solution for $r=0$ and $r=2$.
+Plugging $y=e^{rx}$ into the DE and simplifying
+\begin{equation}
+r^2+2r-8=0
+\end{equation}
+This is a solution when $r=2$ or $r=-4$.
 }
 
 
 \begin{exercise}
-Verify that $x=C_1e^t+C_2$ is a solution to $x''-x' = 0$.  Find $C_1$ and
-$C_2$ so that $x$ satisfies $x(0) = 10$ and $x'(0) = 100$.
+	Verify that $x = C e^{-2t}$ is a solution to $x' = -2x$.
+	Find $C$ to solve for the initial condition $x(0) = 100$.
 \end{exercise}
 \exsol{%
-$C_1 = 100$, $C_2 = -90$
+$C=100$
 }
 
 \begin{exercise}
-Solve $\frac{d\varphi}{ds} = 8 \varphi$ and $\varphi(0) = -9$.
+	Verify that $x = C_1 e^{-t} + C_2 e^{2t}$ is a solution to $x'' - x' -2 x =
+	0$.  Find $C_1$ and $C_2$ to solve for the initial conditions $x(0) = 10$
+	and $x'(0) = 0$.
 \end{exercise}
 \exsol{%
-$\varphi = -9 e^{8s}$
+$C_1=10/3$, $C_2=20/3$
 }
 
 \begin{exercise}
-Solve:
-\begin{tasks}(2)
-\task $\dfrac{dx}{dt} = -4x, \quad x(0)=9$
-\task $\dfrac{d^2x}{dt^2} = -4x, \quad x(0)=1, \quad x'(0)=2$
-\task $\dfrac{dp}{dq} = 3 p, \quad p(0)=4$
-\task $\dfrac{d^2T}{dx^2} = 4 T, \quad T(0)=0, \quad T'(0)=6$
-\end{tasks}
+	Find a solution to
+	${(x')}^2 + x^2 = 4$
+	using your knowledge of derivatives of functions that you
+	know from basic calculus.
 \end{exercise}
 \exsol{%
-a)~$x=9e^{-4t}$ \quad
-b)~$x=\cos(2t)+\sin(2t)$ \quad
-c)~$p=4e^{3q}$ \quad
-d)~$T=3\sinh(2x)$
+$x=2\sin t$ or $x=2\cos t$.
+}
+
+\begin{exercise}
+	Solve:
+	\begin{tasks}(2)
+		\task $\dfrac{dA}{dt} = -10 A, \quad A(0)=5$
+		\task $\dfrac{dH}{dx} = 3 H, \quad H(0)=1$
+		\task $\dfrac{d^2y}{dx^2} = 4 y, \quad y(0)=0, \quad y'(0)=1$
+		\task $\dfrac{d^2x}{dy^2} = -9 x, \quad x(0)=1, \quad x'(0)=0$
+	\end{tasks}
+\end{exercise}
+\exsol{%
+a) $A=5e^{-10t}$\quad
+b) $H=e^{3x}$ \quad
+c) $y=1/2(e^{2x}-e^{-2x})$ \quad
+d) Here $k^2=9$, so the general solution is 
+\begin{equation*}
+x=c_1\cos 3y+c_2\sin 3y \quad \rightarrow
+x'=-3c_1\sin 3y +3c_2\cos 3y
+\end{equation*}
+Plugging in the initial conditions we find $c_1=1$, $c_2=0$ therefore $x=\cos 3y$.
+}
+
+
+\begin{exercise}
+	Is there a solution to $y' = y$, such that $y(0) = y(1)$?
+\end{exercise}
+\exsol{%
+    Only the trivial solution $y=0$.
+}
+
+\begin{exercise}
+	The population of city X was 100 thousand 20 years ago, and 
+	the population of city X was 120 thousand 10 years ago.  Assuming constant
+	growth, you can use the exponential population model
+	(like for the bacteria).  What do you estimate the population is now?
+\end{exercise}
+\exsol{%
+Set the time 20 years ago as $t=0$, 10 years ago as $t=10$, and now as $t=20$. Using $P(t)=Ce^{kt}$, and $P(0)=100=C$ and $P(10)=100e^{10k}=120\rightarrow\quad k=0.0182$, then
+\begin{equation*}
+P(20)=100e^{0.0182\times 20}\approx 144
+\end{equation*}
+}
+
+\begin{exercise}
+	Suppose that a football coach gets a salary of
+	one million dollars now, and a raise of $10\%$ every year
+	(so exponential model, like population of bacteria).
+	Let $s$ be the salary in millions of dollars, and $t$ is time in years.
+	\begin{tasks}(2)
+		\task
+		What is $s(0)$ and $s(1)$.
+		\task
+		Approximately how many years will it take for the salary to be 10 million.
+		\task
+		Approximately how many years will it take for the salary to be 20 million.
+		\task
+		Approximately how many years will it take for the salary to be 30 million.
+	\end{tasks}
+\end{exercise}
+\exsol{%
+a) $s(0)=1$, $s(1)=1.1$ \quad
+b) $t_{10}\approx 24$ years \quad
+c) $t_{20}\approx 31$ years \quad
+d) $t_{30}\approx 37$ years
+}
+
+
+
+
+
+
+\begin{exercise}
+	Show that $x = e^{-2t}$ is a solution to $x'' + 4x' + 4x = 0$.
+\end{exercise}
+\exsol{%
+	Compute $x' = -2e^{-2t}$ and $x'' = 4e^{-2t}$.  Then
+	$(4e^{-2t}) + 4 (-2e^{-2t}) + 4 (e^{-2t}) = 0$.
+}
+
+\begin{exercise}
+	Is $y = x^2$ a solution to $x^2y'' - 2y = 0$?  Justify.
+\end{exercise}
+\exsol{%
+	Yes.
+}
+
+\begin{exercise}
+	Let $xy'' - y' = 0$.  Try a solution of the form $y = x^r$.  Is this a
+	solution for some $r$?  If so, find all such $r$.
+\end{exercise}
+\exsol{%
+	$y=x^r$ is a solution for $r=0$ and $r=2$.
+}
+
+
+\begin{exercise}
+	Verify that $x=C_1e^t+C_2$ is a solution to $x''-x' = 0$.  Find $C_1$ and
+	$C_2$ so that $x$ satisfies $x(0) = 10$ and $x'(0) = 100$.
+\end{exercise}
+\exsol{%
+	$C_1 = 100$, $C_2 = -90$
+}
+
+\begin{exercise}
+	Solve $\frac{d\varphi}{ds} = 8 \varphi$ and $\varphi(0) = -9$.
+\end{exercise}
+\exsol{%
+	$\varphi = -9 e^{8s}$
+}
+
+\begin{exercise}
+	Solve:
+	\begin{tasks}(2)
+		\task $\dfrac{dx}{dt} = -4x, \quad x(0)=9$
+		\task $\dfrac{d^2x}{dt^2} = -4x, \quad x(0)=1, \quad x'(0)=2$
+		\task $\dfrac{dp}{dq} = 3 p, \quad p(0)=4$
+		\task $\dfrac{d^2T}{dx^2} = 4 T, \quad T(0)=0, \quad T'(0)=6$
+	\end{tasks}
+\end{exercise}
+\exsol{%
+	a)~$x=9e^{-4t}$ \quad
+	b)~$x=\cos(2t)+\sin(2t)$ \quad
+	c)~$p=4e^{3q}$ \quad
+	d)~$T=3\sinh(2x)$
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -857,92 +899,120 @@ vibrations or
 \subsection{Exercises}
 
 \begin{exercise}
-Classify the following equations.  Are they ODE or PDE\@?  Is it an equation
-or a system?  What is the order?  Is it linear or nonlinear, and if it is
-linear, is it homogeneous, constant coefficient?  If it is an ODE\@, is it
-autonomous?
-\begin{tasks}(2)
-\task $\displaystyle \sin(t) \frac{d^2 x}{dt^2} + \cos(t) x = t^2$
-\task $\displaystyle \frac{\partial u}{\partial x} + 3 \frac{\partial u}{\partial y} = xy$
-\task $\displaystyle y''+3y+5x=0, \quad x''+x-y=0$
-\task $\displaystyle \frac{\partial^2 u}{\partial t^2} + u\frac{\partial^2 u}{\partial s^2} =
-0$
-\task $\displaystyle x''+tx^2=t$
-\task $\displaystyle \frac{d^4 x}{dt^4} = 0$
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-If $\vec{u} = (u_1,u_2,u_3)$ is a vector, we have the divergence
-$\nabla \cdot \vec{u} =
-\frac{\partial u_1}{\partial x} +
-\frac{\partial u_2}{\partial y} +
-\frac{\partial u_3}{\partial z}$ and curl
-$\nabla \times \vec{u} =
-\Bigl(
-\frac{\partial u_3}{\partial y} - \frac{\partial u_2}{\partial z} , ~
-\frac{\partial u_1}{\partial z} - \frac{\partial u_3}{\partial x} , ~
-\frac{\partial u_2}{\partial x} - \frac{\partial u_1}{\partial y} \Bigr)$.
-Notice that curl of a vector is still a vector.  Write out Maxwell's
-equations in terms of partial derivatives and classify the system.
-\end{exercise}
-
-\begin{exercise}
-Suppose $F$ is a linear function, that is,
-$F(x,y) = ax+by$ for constants $a$ and $b$.  What is the
-classification of equations of the form $F(y',y) = 0$.
-\end{exercise}
-
-\begin{exercise}
-Write down an explicit example of a third order, linear, nonconstant coefficient,
-nonautonomous, nonhomogeneous system of two ODE such that every derivative
-that could appear, does appear.
-\end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Classify the following equations.  Are they ODE or PDE\@?  Is it an equation
-or a system?  What is the order?  Is it linear or nonlinear, and if it is
-linear, is it homogeneous, constant coefficient?  If it is an ODE\@, is it
-autonomous?
-\begin{tasks}(2)
-\task $\displaystyle \frac{\partial^2 v}{\partial x^2} + 3 \frac{\partial^2
-v}{\partial y^2} = \sin(x)$
-\task $\displaystyle \frac{d x}{dt} + \cos(t) x = t^2+t+1$
-\task $\displaystyle \frac{d^7 F}{dx^7} = 3F(x)$
-\task $\displaystyle y''+8y'=1$
-\task $\displaystyle x''+tyx'=0, \quad y''+txy = 0$
-\task $\displaystyle \frac{\partial u}{\partial t} = \frac{\partial^2 u}{\partial s^2} + u^2$
-\end{tasks}
+	Classify the following equations.  Are they ODE or PDE\@?  Is it an equation
+	or a system?  What is the order?  Is it linear or nonlinear, and if it is
+	linear, is it homogeneous, constant coefficient?  If it is an ODE\@, is it
+	autonomous?
+	\begin{tasks}(2)
+		\task $\displaystyle \sin(t) \frac{d^2 x}{dt^2} + \cos(t) x = t^2$
+		\task $\displaystyle \frac{\partial u}{\partial x} + 3 \frac{\partial u}{\partial y} = xy$
+		\task $\displaystyle y''+3y+5x=0, \quad x''+x-y=0$
+		\task $\displaystyle \frac{\partial^2 u}{\partial t^2} + u\frac{\partial^2 u}{\partial s^2} =
+		0$
+		\task $\displaystyle x''+tx^2=t$
+		\task $\displaystyle \frac{d^4 x}{dt^4} = 0$
+	\end{tasks}
 \end{exercise}
 \exsol{%
-a) 
-PDE\@, equation, second order, linear, nonhomogeneous, constant coefficient.\\
-b) 
-ODE\@, equation, first order, linear, nonhomogeneous, not constant coefficient, not autonomous.\\
-c) 
-ODE\@, equation, seventh order, linear, homogeneous, constant coefficient, autonomous.\\
-d) 
-ODE\@, equation, second order, linear, nonhomogeneous, constant coefficient, autonomous.\\
-e) 
-ODE\@, system, second order, nonlinear.\\
-f) 
-PDE\@, equation, second order, nonlinear.
+    
+   a) ODE, equation, second order, linear, non homogeneous, non constant coefficient, non autonomous. \\
+   b) PDE, Equation, first order, linear, non homogeneous, constant coefficient. \\
+    c) ODE, system, second order, linear, homogeneous, constant coefficient, autonomous. Note: independent variable is t here. \\
+    d) PDE, equation, second order, non linear. \\
+   e) ODE, equation, second order, non linear, non autonomous. \\
+    f) ODE, equation, fourth order, linear, homogeneous, constant coefficient, autonomous.\\
 }
 
 \begin{exercise}
-Write down the general \emph{zero}th order linear ordinary differential
-equation.  Write down the general solution.
+	If $\vec{u} = (u_1,u_2,u_3)$ is a vector, we have the divergence
+	$\nabla \cdot \vec{u} =
+	\frac{\partial u_1}{\partial x} +
+	\frac{\partial u_2}{\partial y} +
+	\frac{\partial u_3}{\partial z}$ and curl
+	$\nabla \times \vec{u} =
+	\Bigl(
+	\frac{\partial u_3}{\partial y} - \frac{\partial u_2}{\partial z} , ~
+	\frac{\partial u_1}{\partial z} - \frac{\partial u_3}{\partial x} , ~
+	\frac{\partial u_2}{\partial x} - \frac{\partial u_1}{\partial y} \Bigr)$.
+	Notice that curl of a vector is still a vector.  Write out Maxwell's
+	equations in terms of partial derivatives and classify the system.
 \end{exercise}
 \exsol{%
-equation: $a(x) y = b(x)$, solution: $y = \frac{b(x)}{a(x)}$.
+    \begin{align*}
+    \frac{\partial D_1}{\partial x}+\frac{\partial D_2}{\partial y}+\frac{\partial D_3}{\partial z}=\rho, &\quad \frac{\partial B_1}{\partial x}+\frac{\partial B_2}{\partial y}+\frac{\partial B_3}{\partial z}=0 
+    \\
+    \frac{\partial E_3}{\partial y}-\frac{\partial E_2}{\partial z}=-\frac{\partial B_1}{\partial t}, &\quad 
+    \frac{\partial H_3}{\partial y}-\frac{\partial H_2}{\partial z}=\frac{\partial D_1}{\partial t}+J_1  
+    \\
+    \frac{\partial E_1}{\partial z}-\frac{\partial E_3}{\partial x}=-\frac{\partial B_2}{\partial t}, &\quad 
+    \frac{\partial H_1}{\partial z}-\frac{\partial H_3}{\partial x}=\frac{\partial D_2}{\partial t}+J_2 
+    \\ 
+    \frac{\partial E_2}{\partial x}-\frac{\partial E_1}{\partial y}=-\frac{\partial B_3}{\partial t}, &\quad 
+    \frac{\partial H_2}{\partial x}-\frac{\partial H_1}{\partial y}=\frac{\partial D_3}{\partial t}+J_3 
+    \end{align*}
+    PDE, system, first order, linear, nonhomogeneous, constant coefficient, autonomous.
 }
 
 \begin{exercise}
-For which $k$ is $\frac{dx}{dt}+x^k = t^{k+2}$ linear.  Hint: there are two answers.
+	Suppose $F$ is a linear function, that is,
+	$F(x,y) = ax+by$ for constants $a$ and $b$.  What is the
+	classification of equations of the form $F(y',y) = 0$.
 \end{exercise}
 \exsol{%
-$k=0$ or $k=1$
+ODE, linear, homogeneous, constant coefficient, autonomous.
 }
 
+\begin{exercise}
+	Write down an explicit example of a third order, linear, nonconstant coefficient,
+	nonautonomous, nonhomogeneous system of two ODE such that every derivative
+	that could appear, does appear.
+\end{exercise}
+\exsol{%
+    An example would be
+$y'''+xy''+y'+y=3x^2$.
+}
+
+\begin{exercise}
+	Classify the following equations.  Are they ODE or PDE\@?  Is it an equation
+	or a system?  What is the order?  Is it linear or nonlinear, and if it is
+	linear, is it homogeneous, constant coefficient?  If it is an ODE\@, is it
+	autonomous?
+	\begin{tasks}(2)
+		\task $\displaystyle \frac{\partial^2 v}{\partial x^2} + 3 \frac{\partial^2
+			v}{\partial y^2} = \sin(x)$
+		\task $\displaystyle \frac{d x}{dt} + \cos(t) x = t^2+t+1$
+		\task $\displaystyle \frac{d^7 F}{dx^7} = 3F(x)$
+		\task $\displaystyle y''+8y'=1$
+		\task $\displaystyle x''+tyx'=0, \quad y''+txy = 0$
+		\task $\displaystyle \frac{\partial u}{\partial t} = \frac{\partial^2 u}{\partial s^2} + u^2$
+	\end{tasks}
+\end{exercise}
+\exsol{%
+	a) 
+	PDE\@, equation, second order, linear, nonhomogeneous, constant coefficient.\\
+	b) 
+	ODE\@, equation, first order, linear, nonhomogeneous, not constant coefficient, not autonomous.\\
+	c) 
+	ODE\@, equation, seventh order, linear, homogeneous, constant coefficient, autonomous.\\
+	d) 
+	ODE\@, equation, second order, linear, nonhomogeneous, constant coefficient, autonomous.\\
+	e) 
+	ODE\@, system, second order, nonlinear.\\
+	f) 
+	PDE\@, equation, second order, nonlinear.
+}
+
+\begin{exercise}
+	Write down the general \emph{zero}th order linear ordinary differential
+	equation.  Write down the general solution.
+\end{exercise}
+\exsol{%
+	equation: $a(x) y = b(x)$, solution: $y = \frac{b(x)}{a(x)}$.
+}
+
+\begin{exercise}
+	For which $k$ is $\frac{dx}{dt}+x^k = t^{k+2}$ linear.  Hint: there are two answers.
+\end{exercise}
+\exsol{%
+	$k=0$ or $k=1$
+}

--- a/ch-intro.tex
+++ b/ch-intro.tex
@@ -9,202 +9,10 @@
 \section{Notes about these notes}
 \label{notes:section}
 
-\sectionnotes{A section for the instructor.}
+This version of the textbook is for the Ordinary Differential Equations portion of Math 204 at the Univesrity of Victoria. This version is a fork with adaption by Trefor Bazett of the original text by Jiří Lebl. If you are an instructor,  \href{https://www.jirka.org/diffyqs/html/notes_section.html}{please consult the original version of the text} for more information and potential uses.
 
-This book originated from my class notes for Math 286
-at the \href{https://www.math.uiuc.edu/}{University of Illinois at
-Urbana-Champaign} (UIUC)
-in Fall 2008 and
-Spring 2009.
-It is a first course on differential equations for engineers.
-Using this book, I also taught Math 285 at UIUC\@,
-Math 20D at
-\href{https://www.math.ucsd.edu/}{University of California, San Diego} (UCSD),
-and Math 4233 at 
-\href{https://math.okstate.edu/}{Oklahoma State University} (OSU).
-Normally these courses are taught with
-Edwards and Penney, \emph{Differential
-Equations and Boundary Value Problems: Computing and Modeling}~\cite{EP}, or
-Boyce and DiPrima's
-\emph{Elementary
-Differential Equations and Boundary Value Problems}~\cite{BD},
-and this book aims to be more or less a drop-in replacement.
-Other books I used as sources of information and inspiration
-are E.L.\ Ince's classic (and inexpensive)
-\emph{Ordinary Differential Equations}~\cite{I},
-Stanley Farlow's \emph{Differential Equations and Their
-Applications}~\cite{F}, now available from Dover,
-Berg and McGregor's
-\emph{Elementary Partial Differential Equations}~\cite{BM},
-and William Trench's free book
-\emph{Elementary
-Differential Equations with Boundary Value Problems}~\cite{T}.
-See the \hyperref[furtherreading:chapter]{Further Reading} chapter at the end of the book.
 
-\subsection{Organization}
 
-The organization of this book to some degree
-requires chapters be done in order.
-Later chapters can be dropped.
-The dependence of the material covered is roughly:
-
-% If changing make sure to also update figures/chapterdiagram.pdf_t
-% That's a hopefully short term hack before I figure out how to do it
-% better so that it also gets links and such
-%mbxSTARTIGNORE
-\begin{equation*}
-\begin{tikzcd}[cramped, row sep=small]
-& {\text{\hyperref[intro:chapter]{Introduction}}} \arrow[d] \\
-{\text{\Appendixref{linalg:appendix}}} \arrow[dd, dotted]
-& {\text{\Chapterref{fo:chapter}}} \arrow[d] \\
-& {\text{\Chapterref{ho:chapter}}} \arrow[dddr] \arrow[dd] \arrow[dl] \arrow[dr] \\
-{\text{\Chapterref{sys:chapter}}} \arrow[dr, dotted] \arrow[d] & &
-  {\text{\Chapterref{ps:chapter}}} \\
-{\text{\Chapterref{nlin:chapter}}} & {\text{\Chapterref{FS:chapter}}} \arrow[d]
-\arrow[dr,dotted] \\
-& {\text{\Chapterref{SL:chapter}}}
-& {\text{\Chapterref{LT:chapter}}}
-\end{tikzcd}
-\end{equation*}
-%mbxENDIGNORE
-%mbxlatex \begin{center}
-%mbxlatex \inputpdft{chapterdiagram}
-%mbxlatex \end{center}
-
-There are a few references in chapters \ref{FS:chapter} and \ref{SL:chapter}
-to \chapterref{sys:chapter} (some linear algebra), but these
-references are not essential and can be skimmed over,
-so \chapterref{sys:chapter}
-can safely be dropped, while still covering
-chapters \ref{FS:chapter} and \ref{SL:chapter}.
-\Chapterref{LT:chapter} does not depend on 
-\chapterref{FS:chapter} except that the
-PDE section \ref{laplacepde:section} makes a
-few references to
-\chapterref{FS:chapter},
-although it could, in theory, be covered
-separately.
-The more in-depth \appendixref{linalg:appendix} on linear algebra
-can replace the short review \sectionref{sec:matrix}
-for a course that combines linear algebra and ODE\@.
-
-%\medskip
-\subsection{Typical types of courses}
-
-Several typical types of courses can be run with the book.
-There are the two original courses at UIUC\@,
-both cover ODE as well some PDE\@.
-Either, there is the 4 hours-a-week for a semester (Math 286 at UIUC):
-
-\medskip
-
-\noindent
-\hyperref[intro:chapter]{Introduction} (\ref{introde:section}),
-\chapterref{fo:chapter} (\ref{integralsols:section}--\ref{numer:section}),
-\chapterref{ho:chapter},
-\chapterref{sys:chapter},
-\chapterref{FS:chapter} (\ref{bvp:section}--\ref{dirich:section}),
-\chapterref{SL:chapter} (or
-\ref{LT:chapter} or \ref{ps:chapter} or \ref{nlin:chapter}).
-
-\medskip
-
-Or, the second course at UIUC is at 3 hours-a-week (Math 285 at UIUC):
-
-\medskip
-
-\noindent
-\hyperref[intro:chapter]{Introduction} (\ref{introde:section}),
-\chapterref{fo:chapter} (\ref{integralsols:section}--\ref{numer:section}),
-\chapterref{ho:chapter},
-\chapterref{FS:chapter} (\ref{bvp:section}--\ref{dirich:section}),
-(and maybe \chapterref{SL:chapter},
-\ref{LT:chapter}, or \ref{ps:chapter}).
-
-\medskip
-
-A semester-long course at 3 hours a week that doesn't cover either systems or PDE
-will cover, beyond the introduction,
-%\sectionref{introde:section},
-\chapterref{fo:chapter},
-\chapterref{ho:chapter},
-\chapterref{LT:chapter}, and \chapterref{ps:chapter},
-(with sections skipped as above).
-On the other hand, a typical course that covers 
-systems will probably need to skip Laplace and power series
-and cover
-%\sectionref{introde:section},
-\chapterref{fo:chapter},
-\chapterref{ho:chapter},
-\chapterref{sys:chapter}, and \chapterref{nlin:chapter}.
-
-\medskip
-
-If sections need to be skipped in the beginning, a good core of the 
-sections on single ODE is:
-\ref{introde:section},
-\ref{integralsols:section}--\ref{intfactor:section},
-\ref{auteq:section},
-\ref{solinear:section},
-\ref{sec:ccsol},
-\ref{sec:mv}--\ref{forcedo:section}.
-
-\medskip
-
-The complete book can be covered at a reasonably
-fast pace at approximately 76 lectures
-(without \appendixref{linalg:appendix})
-or 86 lectures (with \appendixref{linalg:appendix} replacing
-\sectionref{sec:matrix}).
-This is not accounting for exams, review,
-or time spent in a computer lab. % (if using IODE for example).
-A two-quarter or a two-semester course can be easily run with the material.
-For example (with some sections perhaps strategically skipped):
-
-\medskip
-
-\noindent
-Semester 1:
-\hyperref[intro:chapter]{Introduction},
-\chapterref{fo:chapter},
-\chapterref{ho:chapter},
-\chapterref{LT:chapter},
-\chapterref{ps:chapter}.
-\\
-Semester 2: 
-\Chapterref{sys:chapter},
-\chapterref{nlin:chapter},
-\chapterref{FS:chapter},
-\chapterref{SL:chapter}.
-
-\medskip
-
-A combined course on ODE with linear algebra can run as:
-
-\medskip
-
-\noindent
-\hyperref[intro:chapter]{Introduction},
-\chapterref{fo:chapter} (\ref{integralsols:section}--\ref{numer:section}),
-\chapterref{ho:chapter},
-\appendixref{linalg:appendix},
-\chapterref{sys:chapter} (w/o \sectionref{sec:matrix}), (possibly 
-\chapterref{nlin:chapter}).
-
-\medskip
-
-The chapter on
-the Laplace transform (\chapterref{LT:chapter}),
-the chapter on Sturm--Liouville (\chapterref{SL:chapter}),
-the chapter on power series (\chapterref{ps:chapter}),
-and the chapter on nonlinear systems (\chapterref{nlin:chapter}),
-are more or less interchangeable and can be treated as \myquote{topics}.
-If \chapterref{nlin:chapter} is covered, it may be best to place it right 
-after \chapterref{sys:chapter},
-and \chapterref{SL:chapter} is best covered right after
-\chapterref{FS:chapter}.
-If time is short, the first two sections of
-\chapterref{ps:chapter} make a reasonable self-contained unit.
 
 %\medskip
 \subsection{Computer resources}
@@ -220,7 +28,7 @@ for most sections, customized for this book.
 \item The PDFs of the figures used in this book.
 \end{enumerate}
 
-I taught the UIUC courses using IODE\index{IODE software}
+Jiří Lebl taught the UIUC courses using IODE\index{IODE software}
 (\url{https://faculty.math.illinois.edu/iode/}).
 IODE is a free software package that
 works with Matlab (proprietary) or Octave (free software).
@@ -241,7 +49,9 @@ at github (\url{https://github.com/jirilebl/diffyqs}).
 
 \subsection{Acknowledgments}
 
-Firstly, I would like to acknowledge Rick Laugesen.  I used his handwritten
+Acknowlegements by Trefor Bazett: Firstly, I want to thank the incredibly work of Ji\v{r}\'i Lebl for creating and maintaining this excellent textbook, without which this project would have been beyond daunting to begin. I want to thank both Afif Omar and Muhammad Awais for their extensive work on revising the exercises, answers, and solutions. This project is supported by an grant through the LTSI at the University of Victoria to create Open Educational Resources. 
+
+Acknowledgements by Ji\v{r}\'i Lebl: Firstly, I would like to acknowledge Rick Laugesen.  I used his handwritten
 class notes
 the first time I taught
 Math 286.  My organization of this book through chapter 5,

--- a/ch-intro.tex
+++ b/ch-intro.tex
@@ -9,7 +9,10 @@
 \section{About this book}
 \label{notes:section}
 
-This version of the book is for the Ordinary Differential Equations portion of Math 204 at the University of Victoria. This version is a fork adapted by Trefor Bazett of the original text by Jiří Lebl.
+This version of the book is for the Ordinary Differential Equations portion of Math 204 at the University of Victoria. This version is a fork of the original textbook adapted for Math 204. Trefor Bazett is the project lead, and the adaption has had contributions by Muhammad Awais and Afif Omar.
+
+\subsection{Math 204: Vector Calculus and Differential Equations}
+Math 204 at UVic consists of a Vector Calculus portion followed by Ordinary Differential Equations (ODEs). This book covers the ODE portion, while this separate \href{https://web.uvic.ca/~tbazett/VectorCalculus/frontmatter-1.html}{Vector Calculus "Book"} supports the Vector Calculus portion. 
 
 \subsection{Original Textbook by Jiří Lebl}
 
@@ -33,12 +36,12 @@ As of this writing, the original text by Jiří Lebl and the forked version by T
 A few chapters in this book are not taught in Math 204, namely Systems, Non-Linear Systems, Eigenvalue Systems, and PDEs. These chapters remain for reference purposes in the forked version of the textbook entirely untouched by Trefor Bazett. 
 
 \subsection{The video playlist}
-The full playlist of videos \href{https://www.youtube.com/playlist?list=PLQ9f-JfDG2WyBPsKFkkfszurhIYeKN6oX}{can be found here}, and consists of both Vector Calculus (not covered in this textbook) and ODEs (covering this textbook). The individual videos are embedded throughout the text. 
+The full playlist of videos by Trefor Bazett \href{https://www.youtube.com/playlist?list=PLQ9f-JfDG2WyBPsKFkkfszurhIYeKN6oX}{can be found here}, and consists of both Vector Calculus (embedded in the \href{https://web.uvic.ca/~tbazett/VectorCalculus/frontmatter-1.html}{Vector Calculus "Book"}) and ODEs (embedded throughout this book). 
 
 The videos are intended to be complimentary to the textbook. You could learn the content just by reading the textbook, as in the original version by Lebl. The other direction is not true; the videos alone don't always
 cover all the content. Typically the videos use slightly different examples from the textbook so that you can get extra exposure by reading/watching both. While there was an effort for the notation and scope of the videos to be similar to the textbook, ultimately the book is largely written by Lebl and the videos recorded by Bazett and there are stylistic differences and differences in emphasis between these two. Typically videos are placed immediately prior to the analogous text content covered in the video.
 
-
+Note that the videos used in this text are one Trefor Bazett's UVic-specific channel \href{https://youtube.com/@DrTreforUVic}{@DrTreforUVic}. Trefor Bazett also maintains a public YouTube channel which contain versions of the same videos. In general the videos embedded from the @DrTreforUVic channel are a cleaner learning experience as they are not monetized and contain no calls-to-action (eg: Like and Subscribe!). 
 
 \subsection{Computer resources}
 
@@ -69,7 +72,7 @@ The \LaTeX\ source is available on github for the original version by Lebl (\url
 
 
 
-Acknowlegements by Trefor Bazett: Firstly, I want to thank the incredibly work of Ji\v{r}\'i Lebl for creating and maintaining this excellent textbook, without which this project would have been beyond daunting to begin. I want to thank both Afif Omar and Muhammad Awais for their extensive work on revising the exercises, answers, and solutions. This project is supported by a grant through the LTSI at the University of Victoria to create Open Educational Resources. 
+Acknowlegements by Trefor Bazett: Firstly, I want to thank the incredibly work of Ji\v{r}\'i Lebl for creating and maintaining this excellent textbook, without which this project would have been beyond daunting to begin. I want to thank both Muhammad Awais and Afif Omar for their extensive work on revising the exercises, answers, and solutions. This project is supported by a grant through the LTSI at the University of Victoria to create Open Educational Resources. 
 
 Acknowledgements by Ji\v{r}\'i Lebl: Firstly, I would like to acknowledge Rick Laugesen.  I used his handwritten
 class notes
@@ -557,7 +560,7 @@ $C=100$
 	and $x'(0) = 0$.
 \end{exercise}
 \exsol{%
-$C_1=10/3$, $C_2=20/3$
+$C_1=20/3$, $C_2=10/3$
 }
 
 \begin{exercise}

--- a/ch-laplace.tex
+++ b/ch-laplace.tex
@@ -5,11 +5,10 @@
 \section{The Laplace transform}
 \label{laplace:section}
 
-\sectionnotes{1.5--2 lectures\EPref{, \S10.1 in \cite{EP}}\BDref{,
-\S6.1 and parts of \S6.2 in \cite{BD}}}
-
 \subsection{The transform}
-
+\begin{video}[iJVyAwmkAYY][Intro to Laplace Transform][la-intro]
+In this video we introduce the Laplace Transform which takes in functions and outputs a different type of a function. This is going to seem rather strange and unmotivated a bit, because the proof is really in the pudding here that Laplace Transforms are useful for us in how powerful they are to solve differential equations. One benefit is going to happen right away: we will see how to transform very discontinuous things like step functions and the gamma function into more reasonable objects.   
+\end{video}
 In this chapter we will discuss the Laplace transform%
 \footnote{Just like the Laplace equation and the Laplacian, the Laplace
 transform is also named after 
@@ -194,8 +193,11 @@ constants).\label{lt:table}}
 \begin{exercise}
 Verify \tablevref{lt:table}.
 \end{exercise}
+\begin{video}[BsAA4xu3wn0][Linearity, Existence, and Inverses of the Laplace Transform][la-linear]
+	The Laplace Transform has a lot properties that mean it behaves nicely. In this video we'll explore three crucial ones: linearity, existence, and inverses. 
+\end{video}
 
-Since the transform is defined by an integral.  We can use the linearity
+Since the transform is defined by an integral, we can use the linearity
 properties of the integral.  For example, suppose $C$ is a constant, then
 \begin{equation*}
 \mathcal{L} \bigl\{ C f(t) \bigr\} =
@@ -427,6 +429,12 @@ more complicated quadratic that may come up in the method of partial
 fractions.  We complete the square and write such quadratics as ${(s+a)}^2+b$
 and then use the shifting property.
 
+\begin{video}[-Rbr_3Cf7Ag][Translation  & Inverse Laplace Transforms of Irreducible Factors][la-inverse]
+	We want to widely expand the set of functions we can take the inverse Laplace transform of. We will learn about a very convenient property called Translation aka Shifting, and see specifically what to do with irreducible factors. 
+
+	\emph{TYPO: In the final example the $sin(2t)$ term should also have an exponential out front and be $\frac{1}{2}e^t\sin(2t)$ for the same reasons}
+\end{video}
+
 \begin{example}
 Find
 ${\mathcal{L}}^{-1} \left\{ \frac{1}{s^2+4s+8} \right\}$.
@@ -446,6 +454,10 @@ Putting it all together with the shifting property, we find
 \frac{1}{2}\,e^{-2t} \sin (2t) .
 \end{equation*}
 \end{example}
+
+\begin{video}[RlJXwoM1DF4][Inverse Laplace Transform with Repeated Factors][la-repeated]
+	\ref{la-inverse} showed us how to take an irreducible quadratic factor and use completing the square to write it in a fashion amendable for taking inverse Laplace transforms. In this video we show how to deal with repeated factors. 
+\end{video}
 
 In general, we want to be able to apply the Laplace transform to
 rational functions, that is functions of the form
@@ -467,31 +479,70 @@ denominator.
 \begin{exercise}
 Find the Laplace transform of $3+t^5+\sin (\pi t)$.
 \end{exercise}
+\exsolution{%
+Using linearity of the Laplace Transform, we write\\\\
+$\mathcal{L}[3+t^5+\sin (\pi t)]=\mathcal{L}[3]+\mathcal{L}[t^{5}]+\mathcal{L}[\sin(\pi t)]=\frac{3}{s}+\frac{120}{s^6}+\frac{\pi }{s^2+\pi ^2}$
+}
 
 \begin{exercise}
 Find the Laplace transform of $a+bt+ct^2$ for some constants $a$, $b$, and
 $c$.
 \end{exercise}
+\exsol{%
+$\frac{a}{s}+\frac{b}{s^2}+\frac{2 c}{s^3}$
+}
 
 \begin{exercise}
 Find the Laplace transform of $A \cos (\omega t) + B \sin (\omega t)$.
 \end{exercise}
+\exsol{%
+$\frac{\alpha  s + \beta  \omega}{s^2+\omega ^2}$
+}
 
 \begin{exercise}
 Find the Laplace transform of $\cos^2 (\omega t)$.
 \end{exercise}
+\exsol{%
+$\frac{s^2+2 \omega ^2}{s^3+4 s \omega ^2}$
+}
+
+\begin{exercise}
+	Find the Laplace transform of $4{(t+1)}^2$.
+\end{exercise}
+\exsol{%
+	$\frac{8}{s^3} + \frac{8}{s^2} + \frac{4}{s}$
+}
+
+\begin{exercise}
+	Find the Laplace transform of $te^{-t}$.  Hint: Laplace by definition, then Integrate by parts.
+\end{exercise}
+\exsol{%
+	$\frac{1}{{(s+1)}^2}$
+}
+
+\begin{exercise}
+	Find the Laplace transform of $\sin(t)e^{-t}$.  Hint: Laplace by definition, then Integrate by parts.
+\end{exercise}
+\exsol{%
+	$\frac{1}{s^2+2s+2}$
+}
 
 \begin{exercise}
 Find the inverse Laplace transform of $\frac{4}{s^2-9}$.
 \end{exercise}
+\exsolution{%
+Using Partial fractions, we write\\\\
+$\frac{4}{s^2-9}=\frac{2}{3}\frac{1}{s-3}-\frac{2}{3}\frac{1}{s+3}$\\\\
+Now taking the inverse Laplace transform, we get\\\\
+$\mathcal{L}^{-1}\left[\frac{4}{s^2-9}\right]=\frac{2}{3}\mathcal{L}^{-1}\left[\frac{1}{s-3}\right]-\frac{2}{3}\mathcal{L}^{-1}\left[\frac{1}{s+3}\right]=\frac{2}{3}e^{3t}-\frac{2}{3}e^{-3t}=\frac{4}{3}\frac{e^{3t}-e^{-3t}}{2}=\frac{4}{3} \sinh (3 t)$
+}
 
 \begin{exercise}
 Find the inverse Laplace transform of $\frac{2s}{s^2-1}$.
 \end{exercise}
-
-\begin{exercise}
-Find the inverse Laplace transform of $\frac{1}{{(s-1)}^2(s+1)}$.
-\end{exercise}
+\exsol{%
+$2 \cosh (t)$
+}
 
 \begin{exercise}
 Find the Laplace transform of $f(t) =
@@ -500,48 +551,63 @@ t & \text{if } \; t \geq 1, \\
 0 & \text{if } \; t < 1.
 \end{cases}$
 \end{exercise}
+\exsolution{%
+Using the definition of the laplace tranform (and the fact that $f(t)$ is non-zero only between 0 and 1):\\\\
+$\mathcal{L}[f(t)]=\int_{0}^{1}te^{-st}dt=\frac{1-e^{-s} (s+1)}{s^2}$
+}
+
+\begin{exercise}
+	Find the Laplace transform of the function whose graph is given below:
+\end{exercise}
+\exsol{%
+$\frac{-1+e^{-s} (s+1)}{s^2}$
+}
+
+\begin{exercise}
+Find the inverse Laplace transform of $\frac{1}{{(s-1)}^2(s+1)}$.
+\end{exercise}
+\exsolution{%
+\textbf{Hint:} Use Partial fractions and then take the inverse Laplace. For one of the terms, you will need the property $\mathcal{L}[e^{-at}f(t)]=F(s+a)$. Inverse Laplace will be given by:\\\\
+$\frac{1}{2} \left[te^t-\sinh (t)\right]$
+}
+
 
 \begin{exercise}
 Find the inverse Laplace transform of $\frac{s}{(s^2+s+2)(s+4)}$.
 \end{exercise}
+\exsolution{%
+Using partial fractions, we write\\\\
+$\mathcal{L}^{-1}\left[\frac{s}{(s^2+s+2)(s+4)}\right]=\mathcal{L}^{-1}\left[\frac{2 s+1}{7 \left(s^2+s+2\right)}-\frac{2}{7 (s+4)}\right]=\frac{2}{7}\mathcal{L}^{-1}\left[\frac{s+(1/2)}{\left(s+(1/2)\right)^{2}+(\sqrt{7}/2)^{2}}-\frac{1}{(s+4)}\right]=\frac{2}{7}\left[e^{-t/2} \cos \left(\frac{\sqrt{7} t}{2}\right)-e^{-4 t}\right]$
+}
+
+\begin{exercise}
+	Find the inverse Laplace transform of $\frac{8}{s^3(s+2)}$.
+\end{exercise}
+\exsol{%
+	$2t^2-2t+1-e^{-2t}$
+}
+
+\begin{exercise}
+	Find the inverse Laplace transform of $\frac{s+1}{s^{2}+2s+10}+\frac{3}{s^{2}+2s+10}$.
+\end{exercise}
+\exsol{%
+$e^{-t} (\sin (3 t)+\cos (3 t))$
+}
 
 \begin{exercise}
 Find the Laplace transform of $\sin\bigl(\omega (t-a)\bigr)$.
 \end{exercise}
+\exsolution{%
+First expand $\sin\bigl(\omega (t-a)\bigr)$ using trig. identity and then apply the Laplace transform. This gives the transform:\\\\
+$\frac{\omega  \cos (a  \omega )}{s^2+\omega ^2}-\frac{s \sin (a  \omega)}{s^2+\omega ^2}$
+}
 
 \begin{exercise}
 Find the Laplace transform of $t\sin(\omega t)$.  Hint: Several integrations
 by parts.
 \end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Find the Laplace transform of $4{(t+1)}^2$.
-\end{exercise}
 \exsol{%
-$\frac{8}{s^3} + \frac{8}{s^2} + \frac{4}{s}$
-}
-
-\begin{exercise}
-Find the inverse Laplace transform of $\frac{8}{s^3(s+2)}$.
-\end{exercise}
-\exsol{%
-$2t^2-2t+1-e^{-2t}$
-}
-
-\begin{exercise}
-Find the Laplace transform of $te^{-t}$.  Hint: Integrate by parts.
-\end{exercise}
-\exsol{%
-$\frac{1}{{(s+1)}^2}$
-}
-
-\begin{exercise}
-Find the Laplace transform of $\sin(t)e^{-t}$.  Hint: Integrate by parts.
-\end{exercise}
-\exsol{%
-$\frac{1}{s^2+2s+2}$
+$\frac{2 s \omega }{\left(s^2+\omega ^2\right)^2}$
 }
 
 
@@ -551,10 +617,18 @@ $\frac{1}{s^2+2s+2}$
 \section{Transforms of derivatives and ODEs}
 \label{transformsofders:section}
 
-\sectionnotes{2 lectures\EPref{, \S7.2--7.3 in \cite{EP}}\BDref{,
-\S6.2 and \S6.3 in \cite{BD}}}
 
 \subsection{Transforms of derivatives}
+
+
+\begin{video}[xWaX-SsKDjU][Transforms of Derivatives and integrals][la-der]
+	The Laplace Transform has a lot properties that mean it behaves nicely. In this video we'll explore three crucial ones: linearity, existence, and inverses. 
+
+	\emph{Correction: The Laplace transform of derivatives is missing some negative signs. Correct expressions for the Laplace of the first, second and third derivatives, respectively are:}
+\[L[f'(t)]=sF(s)−f(0)\]
+\[L[f''(t)]=s2F(s)−sf(0)−f'′(0),\]
+\[L[f'''(t)]=s3F(s)−s2f(0)−sf'(0)−f''(0)\]
+\end{video}
 
 Let us see how the Laplace transform is used for differential equations.
 First let us try to find the Laplace transform of a function that is a
@@ -617,6 +691,10 @@ Notice that the Laplace transform turns differentiation into
 multiplication by $s$.  Let us see how to apply this fact to differential
 equations.
 
+\begin{video}[xGeG03opUCI][How to solve ODEs with the Laplace Transform][la-solve]
+	We finally know enough to go from start to finish. That is, we begin with an ODE. We transform it via the Laplace Transform. We manipulate it over in the world of Laplace Transforms. Then we translate it back to get a solution. Cool!
+\end{video}
+
 \begin{example}
 Take the equation
 \begin{equation*}
@@ -666,7 +744,16 @@ is not a linear constant coefficient ODE\@,
 then by applying the Laplace transform we may not
 obtain an algebraic equation.
 
+\begin{video}[JFvhCgalTMc][Solving an ODE using Laplace Transforms Example][la-odeexample]
+	In this video we put everything together. We start with an IVP we take the Laplace transform of. The solution to the algebraic equation has a partial fraction decomposition with multiple types of factors and we finally take the inverse Laplace Transform to get a solution to the original IVP.
+\end{video}
+
+
 \subsection{Using the Heaviside function}
+
+\begin{video}[2jbSXlQalwk][The Laplace Transform of Piecewise Functions][la-piecewise]
+	A major strength of Laplace Transforms is in how it deals with discontinuities whether piecewise defined functions but even more so periodic functions that repeat the same discontinuous pattern over and over. The Laplace Transform converts these into continuous functions that can often be easier to work with
+\end{video}
 
 Before we move on to more general equations
 than those we could solve before,
@@ -803,6 +890,13 @@ The plot of this solution is given in \figurevref{lt:heavisideexfig}.
 \end{myfig}
 \end{example}
 
+\begin{video}[SpLHM16mFt][Solving an IVP with a piecewise nonhomogeneity ][la-piecewise2]
+	This video is a start to finish walkthrough of the process of going from an IVP, converting via Laplace, dealing with the piecewise part, and then converting back to a solution to the original IVP. This video thus includes many pieces we've been developing so is probably your best check for comprehension yet. Feel free to try and work it out on your own first and skip to the end to check the solution. 
+
+	\emph{TYPO: At about 4:00, in the red, $\mathcal{L}\{u(t-a)f(t-a)\}=e^{-as}\mathcal{L}\{f(t)\}$. I wrote the exponential with a t not an s. This typo persists in a few places in the video}
+\end{video}
+
+
 \subsection{Transfer functions}
 
 The Laplace transform leads to the following useful concept for studying the
@@ -934,9 +1028,28 @@ x(t) = 2 e^{-t} t .
 \subsection{Exercises}
 
 \begin{exercise}
-Using the Heaviside function write down the piecewise function
-that is 0 for $t < 0$, $t^2$ for $t$ in $[0,1]$ and $t$ for $t > 1$.
+	Compute the inverse Laplace transform of the function $F(s)=\frac{1}{s^{2}\left(s-10\right)}$
 \end{exercise}
+\exsolution{%
+	First we write $F(s)=\frac{1}{s}\frac{1}{s\left(s-10\right)}$ and figure out the inverse Laplace transform of $G(s)=\frac{1}{s\left(s-10\right)}$. Using the property for Laplace transform of integrals, we write:
+	\begin{equation}
+	\mathcal{L}^{-1}\left(\frac{1}{s\left(s-10\right)}\right)=\int_{0}^{t}\mathcal{L}^{-1}\left(\frac{1}{s-10}\right)d\tau=\int_{0}^{t}e^{10\tau}d\tau=\frac{1}{10}\left(e^{10t}-1\right)\nonumber
+	\end{equation}
+	Now we write
+	\begin{equation}
+	\mathcal{L}^{-1}\left(\frac{1}{s^{2}\left(s-10\right)}\right)=\int_{0}^{t}\mathcal{L}^{-1}\left(\frac{1}{s\left(s-10\right)}\right)d\tau=\int_{0}^{t}[e^{10\tau}-1] d\tau=\frac{1}{100} \left(-10 t+e^{10 t}-1\right)\nonumber
+	\end{equation}
+}
+
+\begin{exercise}
+Compute the inverse Laplace transform of the function $F(s)=\frac{1}{s^{2}\left(s^{2}+1\right)}$
+\end{exercise}
+\exsolution{%
+Using the example from section above, we know that $\mathcal{L}^{-1}\left(\frac{1}{s\left(s^{2}+1\right)}\right)=1-\cos t$. Using this and the property for Laplace transform of integrals, we write:
+\begin{equation}
+\mathcal{L}^{-1}\left(\frac{1}{s^{2}\left(s^{2}+1\right)}\right)=\mathcal{L}^{-1}\left(\frac{1}{s}\frac{1}{s\left(s^{2}+1\right)}\right)=\int_{0}^{t}\mathcal{L}^{-1}\left(\frac{1}{s\left(s^{2}+1\right)}\right)d\tau=\int_{0}^{t}(1-\cos\tau)d\tau=t-\sin t\nonumber
+\end{equation} 
+}
 
 \begin{exercise}
 Using the Laplace transform solve
@@ -966,22 +1079,26 @@ $c^2 = 4km$ (system is critically damped).
 \end{exercise}
 
 \begin{exercise}
-Solve $x'' + x = u(t-1)$ for initial conditions $x(0) = 0$ and $x'(0) = 0$.
+	Using the Heaviside function write down the piecewise function
+	that is 0 for $t < 0$, $t^2$ for $t$ in $[0,1]$ and $t$ for $t > 1$.
 \end{exercise}
 
 \begin{exercise}
-Show the differentiation of the transform property.  Suppose
-$\mathcal{L} \bigl\{ f(t) \bigr\} = F(s)$, then show
-\begin{equation*}
-\mathcal{L} \bigl\{ -t f(t) \bigr\} = F'(s) .
-\end{equation*}
-Hint: Differentiate under the integral sign.
+Solve $x'' + x = u(t-1)$ for initial conditions $x(0) = 0$ and $x'(0) = 0$.
 \end{exercise}
 
 \begin{exercise}
 Solve $x''' + x = t^3 u(t-1)$ for initial conditions $x(0) = 1$ and $x'(0) =
 0$, $x''(0) = 0$.
 \end{exercise}
+
+\begin{exercise}
+	Solve $x''-x = (t^2-1) u(t-1)$ for initial conditions $x(0)=1$, $x'(0) = 2$
+	using the Laplace transform.
+\end{exercise}
+\exsol{%
+	$x(t) = (2e^{t-1}-t^2-1) u(t-1) -\frac{1}{2}e^{-t}+\frac{3}{2}e^t$
+}
 
 \begin{exercise}
 Show the second shifting property: 
@@ -1024,46 +1141,78 @@ f(t) =
 \end{exercise}
 
 \begin{exercise}
+	Using the Heaviside function $u(t)$, write down the function
+	\begin{equation*}
+	f(t) =
+	\begin{cases}
+	0 & \text{if } \; \phantom{1 \leq {}} t < 1  , \\
+	t-1 & \text{if } \; 1 \leq t < 2 , \\
+	1 & \text{if } \; 2 \leq t .
+	\end{cases}
+	\end{equation*}
+\end{exercise}
+\exsol{%
+	$f(t) =
+	(t-1)\bigl(u(t-1) - u(t-2)\bigr) + 
+	u(t-2)$
+}
+
+\begin{exercise}
+	Find the transfer function for 
+	$x' + x = f(t)$
+	(assuming the initial conditions are zero).
+\end{exercise}
+\exsol{%
+	$H(s) = \frac{1}{s+1}$
+}
+
+\begin{exercise}
 Find the transfer function for 
 $m x'' + c x' + kx = f(t)$
 (assuming the initial conditions are zero).
 \end{exercise}
 
-\setcounter{exercise}{100}
 
 \begin{exercise}
-Using the Heaviside function $u(t)$, write down the function
-\begin{equation*}
-f(t) =
-\begin{cases}
-0 & \text{if } \; \phantom{1 \leq {}} t < 1  , \\
-t-1 & \text{if } \; 1 \leq t < 2 , \\
-1 & \text{if } \; 2 \leq t .
-\end{cases}
-\end{equation*}
+	Show the differentiation of the transform property.  Suppose
+	$\mathcal{L} \bigl\{ f(t) \bigr\} = F(s)$, then show
+	\begin{equation*}
+	\mathcal{L} \bigl\{ -t f(t) \bigr\} = F'(s) .
+	\end{equation*}
+	Hint: Differentiate under the integral sign.
 \end{exercise}
-\exsol{%
-$f(t) =
-(t-1)\bigl(u(t-1) - u(t-2)\bigr) + 
-u(t-2)$
+
+\begin{exercise}
+	Find the Laplace transform of $f(t)=t\sin(3t)$
+	(assuming the initial conditions are zero).
+\end{exercise}
+\exsolution{%
+\begin{equation}
+\mathcal{L}[f(t)]=-\frac{d}{ds}\mathcal{L}[\sin(3t)]=-\frac{d}{ds}\left[\frac{3}{s^{2}+9}\right]=\frac{6s}{(s^{2}+9)^{2}}\nonumber
+\end{equation}
 }
 
 \begin{exercise}
-Solve $x''-x = (t^2-1) u(t-1)$ for initial conditions $x(0)=1$, $x'(0) = 2$
-using the Laplace transform.
+	Find the Laplace transform of $f(t)=te^{t}\sin(3t)$
+	(assuming the initial conditions are zero).
 \end{exercise}
-\exsol{%
-$x(t) = (2e^{t-1}-t^2-1) u(t-1) -\frac{1}{2}e^{-t}+\frac{3}{2}e^t$
+\exsolution{%
+	\begin{equation}
+	\mathcal{L}[f(t)]=-\frac{d}{ds}\mathcal{L}[e^{t}\sin(3t)]=-\frac{d}{ds}\left[\frac{3}{(s-1)^{2}+9}\right]=\frac{6 (s-1)}{\left(s^2-2 s+10\right)^2}\nonumber
+	\end{equation}
 }
- 
+
 \begin{exercise}
-Find the transfer function for 
-$x' + x = f(t)$
-(assuming the initial conditions are zero).
+	Solve the following initial value problem: $tx''+x'=t^{3}$ with $x(0)=0$.
 \end{exercise}
-\exsol{%
-$H(s) = \frac{1}{s+1}$
+\exsolution{%
+	Taking the Laplace transform of the given differential equation, we get
+	\begin{equation}
+	-\frac{d}{ds}\left[s^{2}X(s)-sx(0)-x'(0)\right]+sX(s)-x(0)=\frac{6}{s^{4}}\nonumber
+	\end{equation}
+	This becomes $X'(s)+\frac{1}{s}X(s)=-\frac{6}{s^{6}}$. Solving this, we get $X(s)=\frac{c}{s}+\frac{3}{2s^{5}}$. Taking the inverse Laplace of this we get $x(t)=C+\frac{t^{4}}{16}$.
 }
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1071,10 +1220,15 @@ $H(s) = \frac{1}{s+1}$
 \section{Convolution}
 \label{convolution:section}
 
-\sectionnotes{1 or 1.5 lectures\EPref{, \S7.2 in \cite{EP}}\BDref{,
-\S6.6 in \cite{BD}}}
+
+
+
 
 \subsection{The convolution}
+
+\begin{video}[_LX_58L8SJg][Convolutions][la-convolutions]
+	We know two binary operations on functions - pointwise addition and multiplication - that takes two functions and give a third. The convolution f(t)*g(t) is a new operation, and one that is going to play particularly nicely with the Laplace Transform and be particularly nice for computing inverse Laplace transforms of products. 
+\end{video}
 
 The Laplace transformation of a product is not the product
 of the transforms.  All hope is not lost however.  We simply have to use
@@ -1366,6 +1520,14 @@ $f * g$.
 \end{exercise}
 
 \begin{exercise}
+	Let $f(t) = \cos t$ for $t \geq 0$, and $g(t) = e^{-t}$.  Compute
+	$f * g$.
+\end{exercise}
+\exsol{%
+	$\frac{1}{2}(\cos t + \sin t - e^{-t})$
+}
+
+\begin{exercise}
 Find the solution to
 \begin{equation*}
 m x'' + c x' + k x = f(t) , \quad x(0) = 0, \quad x'(0) = 0 ,
@@ -1396,6 +1558,43 @@ Write the solution as a definite integral.
 \end{exercise}
 
 \begin{exercise}
+	Solve $x''+x = \sin t$, $x(0) = 0$, $x'(0)=0$ using convolution.
+\end{exercise}
+\exsol{%
+	$\frac{1}{2}(\sin t - t \cos t)$
+}
+
+\begin{exercise}
+	Solve $x'''+x' = f(t)$, $x(0) = 0$, $x'(0)=0$, $x''(0)=0$ using convolution.
+	Write the result as a definite integral.
+\end{exercise}
+\exsol{%
+	$\int_0^t f(\tau) \bigl( 1 - \cos (t-\tau)\bigr)~ d\tau$
+}
+
+\begin{exercise}
+	Find the Laplace transform of: $t\int_0^t \cos(t-\tau) sin(\tau) ~ d\tau$
+\end{exercise}
+\exsolution{Using the property of derivatives of the transform and the Convolution property, we write
+	\[\mathcal{L}\left[t\int_0^t \cos(t-\tau) sin(\tau) ~ d\tau\right]=-\frac{d}{ds}\mathcal{L}\left[\int_0^t \cos(t-\tau) sin(\tau) ~ d\tau\right]=-\frac{d}{ds}\left[\mathcal{L}(\cos t)\cdot\mathcal{L}(\sin t)\right]\]
+	\[\hspace*{5in}=-\frac{d}{ds}\left[\frac{s}{(s^{2}+1)}\right]=\frac{3 s^2-1}{\left(s^2+1\right)^3}\]
+}
+
+\begin{exercise}
+	Find the Laplace transform of: $\int_0^t \cos(t-\tau) sin(\tau) ~ d\tau$
+\end{exercise}
+\exsol{%
+	$\frac{s}{(s^{2}+1)^{2}}$
+}
+
+\begin{exercise}
+	Write down the solution to
+	$x''-2x=e^{-t^2}$, $x(0)=0$, $x'(0)=0$ as a
+	definite integral.  Hint: Do not try to compute the
+	Laplace transform of $e^{-t^2}$.
+\end{exercise}
+
+\begin{exercise}
 Solve
 \begin{equation*}
 x(t) =  e^{-t} + \int_0^t \cos(t-\tau) x(\tau) ~ d\tau .
@@ -1413,46 +1612,25 @@ x(t) =  \cos t + \int_0^t \cos(t-\tau) x(\tau) ~ d\tau .
 Compute ${\mathcal{L}}^{-1} \left\{ \frac{s}{{(s^2+4)}^2} \right\}$ using
 convolution.
 \end{exercise}
-
-\begin{exercise}
-Write down the solution to
-$x''-2x=e^{-t^2}$, $x(0)=0$, $x'(0)=0$ as a
-definite integral.  Hint: Do not try to compute the
-Laplace transform of $e^{-t^2}$.
-\end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Let $f(t) = \cos t$ for $t \geq 0$, and $g(t) = e^{-t}$.  Compute
-$f * g$.
-\end{exercise}
-\exsol{%
-$\frac{1}{2}(\cos t + \sin t - e^{-t})$
+\exsolution{First we re-write:
+\[\mathcal{L}^{-1}\left[\frac{s}{(s^{2}+4)^{2}}\right]=\frac{1}{2}\mathcal{L}^{-1}\left[\frac{2}{(s^{2}+4)}\cdot\frac{s}{(s^{2}+4)}\right]\]
+Now using the Convolution property of the Laplace tranform, we write:
+\[\mathcal{L}^{-1}\left[\frac{s}{(s^{2}+4)^{2}}\right]=\frac{1}{2}\sin(2t)\star\cos(2t)=\frac{1}{2}t\sin t\cos t\]
 }
 
 \begin{exercise}
-Compute ${\mathcal{L}}^{-1} \left\{ \frac{5}{s^4+s^2} \right\}$ using
-convolution.
+Compute ${\mathcal{L}}^{-1} \left\{\frac{2}{s^{3}(s-4)}\right\}$ using convolution.
 \end{exercise}
 \exsol{%
-$5t-5\sin t$
-}
-
-
-\begin{exercise}
-Solve $x''+x = \sin t$, $x(0) = 0$, $x'(0)=0$ using convolution.
-\end{exercise}
-\exsol{%
-$\frac{1}{2}(\sin t - t \cos t)$
+$\frac{1}{32}\left(e^{4t}-1-4t-8t^{2}\right)$
 }
 
 \begin{exercise}
-Solve $x'''+x' = f(t)$, $x(0) = 0$, $x'(0)=0$, $x''(0)=0$ using convolution.
-Write the result as a definite integral.
+	Compute ${\mathcal{L}}^{-1} \left\{ \frac{5}{s^4+s^2} \right\}$ using
+	convolution.
 \end{exercise}
 \exsol{%
-$\int_0^t f(\tau) \bigl( 1 - \cos (t-\tau)\bigr)~ d\tau$
+	$5t-5\sin t$
 }
 
 
@@ -1462,10 +1640,14 @@ $\int_0^t f(\tau) \bigl( 1 - \cos (t-\tau)\bigr)~ d\tau$
 \section{Dirac delta and impulse response}
 \label{diracdelta:section}
 
-\sectionnotes{1 or 1.5 lecture\EPref{, \S7.6 in \cite{EP}}\BDref{,
-\S6.5 in \cite{BD}}}
 
 \subsection{Rectangular pulse}
+
+\begin{video}[Yam3Ff_QHvA][The Delta Function][la-delta]
+	This video covers the delta function, which is a sort of infinite spike at one point. It's a bit like hitting a system with a hammer, an impulse at an effectively instantaneous moment of time. We'll study this strange object, in particular computing its Laplace Transform, and thus can now solve systems like a mass on a spring that is hit by a hammer pulse. 
+\end{video}
+
+
 
 Often we study a physical system by putting in a short pulse 
 and then seeing what the system does.
@@ -1759,6 +1941,21 @@ you also know how to obtain the output $x(t)$ for any input $f(t)$
 by simply convolving
 the impulse response and the input $f(t)$.
 
+\subsection{Periodic functions}
+
+\emph{This section currently is only available in video format}
+\begin{video}[zgZe09sdTkc][Laplace Transform of Periodic Functions][la-periodic]
+	Periodic Functions are a much broader category than just sin t and cos t, because we can use any function defined on an interval to construct a periodic function on the real line. Thankfully, Laplace Transform is quite effective at dealing with periodic functions. 
+\end{video}
+
+\begin{video}[TTMdpnZuJ4E][The Laplace Transform of IVPs with Periodic Delta Functions][la-periodic2]
+	Now we turn to solving IVPs that have either a single delta function or periodic delta functions in their forcing terms. 
+
+	\emph{TYPO: The formula is $\mathcal{L}\{\delta_a(t)\}=e^{-as}$. In several places in the video I drop the negative sign.}
+\end{video}
+
+
+
 \subsection{Three-point beam bending}
 \index{three-point beam bending}
 
@@ -1864,106 +2061,118 @@ y(x) = \frac{-{(x-1)}^3}{6} u(x-1) - \frac{x}{4} + \frac{x^3}{12} .
 \end{example}
 
 \subsection{Exercises}
-
+\begin{exercise}
+	Solve (find the impulse response)
+	$x' + a x = \delta(t)$, $x(0) = 0$.
+\end{exercise}
+\exsolution{Taking Laplace transform of the given differential equation and using the initial values, we get
+\begin{equation}
+X(s)=\frac{1}{s+a}\nonumber
+\end{equation}
+Applying the inverse Laplace transform, we get		
+\begin{equation}x(t) = e^{-at}\nonumber\end{equation}
+}
+%$sX+aX = 1$
+%$X = \frac{1}{s+a}$
 \begin{exercise}
 Solve (find the impulse response)
 $x'' + x' + x = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
 \end{exercise}
-
 \begin{exercise}
 Solve (find the impulse response)
 $x'' + 2 x' + x = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
 \end{exercise}
-
 \begin{exercise}
 A pulse can come later and can be bigger.
 Solve 
 $x'' + 4 x = 4\delta(t-1)$, $x(0) = 0$, $x'(0)=0$.
 \end{exercise}
-
 \begin{exercise}
-Suppose that $f(t)$ and $g(t)$ are differentiable functions
-and suppose that $f(t) = g(t) = 0$ for all $t \leq 0$.  Show that
-\begin{equation*}
-(f * g)'(t) = (f' * g)(t) = (f * g')(t) .
-\end{equation*}
+	Solve (find the impulse response)
+	$x'' = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
 \end{exercise}
-
+\exsol{%
+	$x(t) = t$
+}
+\begin{exercise}[challenging]
+	Solve \exampleref{lt:examplebeam} via integrating 4 times in the $x$ variable.
+\end{exercise}
 \begin{exercise}
-Suppose that $L x = \delta(t)$, $x(0) = 0$, $x'(0) = 0$, has the solution
-$x = e^{-t}$ for $t > 0$.  Find the solution to
-$Lx = t^2$, $x(0) = 0$, $x'(0) = 0$ for $t > 0$.
+	Suppose that $L x = \delta(t)$, $x(0) = 0$, $x'(0) = 0$, has the solution
+	$x(t) = \cos(t)$ for $t > 0$.  Find (in closed form) the solution to
+	$Lx = \sin(t)$, $x(0) = 0$, $x'(0) = 0$ for $t > 0$.
 \end{exercise}
-
+\exsolution{Taking the Laplace transform of $L x = \delta(t)$, we can write that $F(s)X(s)=1$ or $X(s)=\frac{1}{F(s)}$. We are given that when we take the inverse Laplace, we get $x(t)=\cos t$ implying that $\mathcal{L}^{-1}\left[1/F(s)\right]=\cos t$. Now, taking the Laplace transform of $Lx=\sin t$. This results in $X(s)=\frac{1}{F(s)}\cdot\frac{1}{s^{2}+1}$. Using the inverse Laplace, we get
+	$x(t) = \cos(t)*\sin(t) = \frac{1}{2} t \sin(t)$
+}
+\begin{exercise}
+	Suppose that $L x = \delta(t)$, $x(0) = 0$, $x'(0) = 0$, has the solution
+	$x = e^{-t}$ for $t > 0$.  Find the solution to
+	$Lx = t^2$, $x(0) = 0$, $x'(0) = 0$ for $t > 0$.
+\end{exercise}
+\begin{exercise}
+	Compute
+	${\mathcal{L}}^{-1} \left\{ \frac{s^2}{s^2+1} \right\}$.
+\end{exercise}
+\exsolution{Re-writing the given expression as:
+	\begin{equation}\frac{s^{2}}{s^{2}+1}=\frac{s^{2}+1-1}{s^{2}+1}=1-\frac{1}{s^{2}+1}\nonumber\end{equation}
+	Applying the inverse transform, we can get
+	\begin{equation}{\mathcal{L}}^{-1} \left\{ \frac{s^2}{s^2+1} \right\}=\delta(t) - \sin(t)\nonumber\end{equation}
+}
+%1 - 1/(s^2+1)
+\begin{exercise}
+	Compute
+	${\mathcal{L}}^{-1} \left\{ \frac{3 s^2 e^{-s} + 2}{s^2} \right\}$.
+\end{exercise}
+\exsol{%
+	$3 \delta(t-1) + 2 t$
+}
 \begin{exercise}
 Compute
 ${\mathcal{L}}^{-1} \left\{ \frac{s^2+s+1}{s^2} \right\}$.
 \end{exercise}
-
-\begin{exercise}[challenging]
-Solve \exampleref{lt:examplebeam} via integrating 4 times in the $x$ variable.
+\begin{exercise}
+	Suppose that $f(t)$ and $g(t)$ are differentiable functions
+	and suppose that $f(t) = g(t) = 0$ for all $t \leq 0$.  Show that
+	\begin{equation*}
+	(f * g)'(t) = (f' * g)(t) = (f * g')(t) .
+	\end{equation*}
 \end{exercise}
-
 \begin{exercise}
 Suppose we have a beam of length $1$ simply supported at the ends and
 suppose that force $F=1$ is applied at $x=\frac{3}{4}$ in the downward
 direction.  Suppose that $EI=1$ for simplicity.  Find the beam deflection
 $y(x)$.
 \end{exercise}
-
-\setcounter{exercise}{100}
-
-\begin{exercise}
-Solve (find the impulse response)
-$x'' = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
-\end{exercise}
-\exsol{%
-$x(t) = t$
-}
-
-\begin{exercise}
-Solve (find the impulse response)
-$x' + a x = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
-\end{exercise}
-\exsol{%
-$x(t) = e^{-at}$
-}
-%$sX+aX = 1$
-%$X = \frac{1}{s+a}$
-
-\begin{exercise}
-Suppose that $L x = \delta(t)$, $x(0) = 0$, $x'(0) = 0$, has the solution
-$x(t) = \cos(t)$ for $t > 0$.  Find (in closed form) the solution to
-$Lx = \sin(t)$, $x(0) = 0$, $x'(0) = 0$ for $t > 0$.
-\end{exercise}
-\exsol{%
-$x(t) = (\cos * \sin)(t) = \frac{1}{2} t \sin(t)$
-}
-
-\begin{exercise}
-Compute
-${\mathcal{L}}^{-1} \left\{ \frac{s^2}{s^2+1} \right\}$.
-\end{exercise}
-\exsol{%
-$\delta(t) - \sin(t)$
-}
-%1 - 1/(s^2+1)
-
-\begin{exercise}
-Compute
-${\mathcal{L}}^{-1} \left\{ \frac{3 s^2 e^{-s} + 2}{s^2} \right\}$.
-\end{exercise}
-\exsol{%
-$3 \delta(t-1) + 2 t$
-}
-
+%\noindent\textbf{Transform of Periodic Functions:} Given that we have a function $f(t)$ which is piecewise continuous on $[0,\infty)]$, periodic with period $T$ ($f(t+T)=f(t)$), and is of exponential order as well. Then, for $s>0$, we can show that:
+%\begin{equation}
+%\mathcal{L}[f(t)]=\frac{1}{1-e^{-sT}}\int_{0}^{T}e^{-st}f(t)dt.
+%\end{equation}
+%\begin{exercise}
+%	Compute the Laplace transform of the function $f(t)$ shown in figure below:
+	%Insert PeriodFunctionExample1.pdf here
+%\end{exercise}
+%\exsolution{We can say that our function $f(t)$ is periodic with period 1 and 
+%	\begin{equation}
+%	f(t)=\begin{cases}1\qquad 0\leq t\leq 1/2\\
+%	0\qquad 1/2<t<1\end{cases}\nonumber
+%	\end{equation}
+%	Using the formula for the Laplace transform of a periodic function, we write:
+%	\begin{equation}\mathcal{L}[f(t)]=\frac{1}{1-e^{-s}}\int_{0}^{1}e^{-st}f(t)dt=\frac{1-e^{-s/2}}{s\left(1-e^{-s}\right)}\nonumber\end{equation}
+%}
+%\begin{exercise}
+%	Compute the Laplace transform of the famous saw-tooth function $f(t)$ shown in figure below:
+	%Insert PeriodFunctionExample2.pdf here
+%\end{exercise}
+%\exsolution{%
+%$\frac{1-e^{-s}(s+1)}{s^{2}(1-e^{-s})}$
+%}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \sectionnewpage
 \section{Solving PDEs with the Laplace transform}
 \label{laplacepde:section}
 
-\sectionnotes{1--1.5 lecture, can be skipped}
 
 The Laplace transform comes from the same family of transforms as does the
 Fourier series\footnote{There is a corresponding Fourier transform

--- a/ch-laplace.tex
+++ b/ch-laplace.tex
@@ -1059,6 +1059,28 @@ m x'' + c x' + k x = 0 , \quad x(0) = a, \quad x'(0) = b ,
 where $m > 0$, $c > 0$, $k > 0$, and
 $c^2 - 4km > 0$ (system is overdamped).
 \end{exercise}
+\exsolution{%
+Taking the Laplace transform
+\begin{align*}
+m\left(s^2X-sa-b\right)+c\left(sX-a\right)+kX=0
+\end{align*}
+Solving for $X$
+\begin{align*}
+X=\frac{mas+mb+ca}{ms^2+cs+k}=\frac{mas}{ms^2+cs+k}+\frac{mb+ca}{ms^2+cs+k}
+\end{align*}
+Completing the square and noting that $4km-c^2<0$ 
+\begin{align*}
+X=a\frac{s}{(s+\frac{c}{2m})^2-\frac{1}{4m^2}(c^2-4km)}+\frac{b+\frac{ca}{m}}{\frac{1}{2m}\sqrt{c^2-4km}}\frac{\overbrace{\frac{1}{2m}\sqrt{c^2-4km}}^{\omega}}{(s+\frac{c}{2m})^2-\frac{1}{4m^2}(c^2-4km)}
+\end{align*}
+Noting the shift $+\frac{c}{2m}$, we rewrite 
+\begin{align*}
+X=a\frac{s+\frac{c}{2m}}{(s+\frac{c}{2m})^2-\frac{1}{4m^2}(c^2-4km)}+\frac{b+\frac{ca}{2m}}{\frac{1}{2m}\sqrt{c^2-4km}}\frac{\frac{1}{2m}\sqrt{c^2-4km}}{(s+\frac{c}{2m})^2-\frac{1}{4m^2}(c^2-4km)}
+\end{align*}
+Now taking the inverse Laplace transform we get
+\begin{align*}
+x(t)=ae^{-\frac{c}{2m}t}\sinh\left(\frac{\sqrt{c^2-4km}}{2m}t\right)+\frac{2mb+ca}{\sqrt{c^2-4km}}e^{-\frac{c}{2m}t}\cosh\left(\frac{\sqrt{c^2-4km}}{2m}t\right)
+\end{align*}
+}
 
 \begin{exercise}
 Using the Laplace transform solve
@@ -1068,6 +1090,9 @@ m x'' + c x' + k x = 0 , \quad x(0) = a, \quad x'(0) = b ,
 where $m > 0$, $c > 0$, $k > 0$, and
 $c^2 - 4km < 0$ (system is underdamped).
 \end{exercise}
+\exsol{%
+$x(t)=ae^{-\frac{c}{2m}t}\sin\left(\frac{\sqrt{4km-c^2}}{2m}t\right)+\frac{2mb+ca}{\sqrt{4km-c^2}}e^{-\frac{c}{2m}t}\cos\left(\frac{\sqrt{4km-c^2}}{2m}t\right)$
+}
 
 \begin{exercise}
 Using the Laplace transform solve
@@ -1077,22 +1102,42 @@ m x'' + c x' + k x = 0 , \quad x(0) = a, \quad x'(0) = b ,
 where $m > 0$, $c > 0$, $k > 0$, and
 $c^2 = 4km$ (system is critically damped).
 \end{exercise}
+\exsol{%
+$x(t)=ae^{-\frac{c}{2m}t}+\left(b+\frac{ca}{2m}\right)e^{-\frac{c}{2m}t}t$
+}
 
 \begin{exercise}
 	Using the Heaviside function write down the piecewise function
 	that is 0 for $t < 0$, $t^2$ for $t$ in $[0,1]$ and $t$ for $t > 1$.
 \end{exercise}
+\exsol{%
+$f(t)=\left(u(t)-u(t-1)\right)t^2+u(t-1)t$
+}
 
 \begin{exercise}
 Solve $x'' + x = u(t-1)$ for initial conditions $x(0) = 0$ and $x'(0) = 0$.
 \end{exercise}
+\exsolution{%
+Taking the Laplace transform 
+\begin{align*}
+s^2X+X= &\frac{e^{-s}}{s} \\
+X=&\frac{e^{-s}}{(s^2+1)s} = e^{-s}\left(\frac{1}{s}-\frac{s}{s^2+1}\right)
+\end{align*}
+Taking the inverse Laplace transform
+\begin{align*}
+x(t)=\left(1-\cos(t-1)\right)u(t-1)
+\end{align*}
+}
 
 \begin{exercise}
-Solve $x''' + x = t^3 u(t-1)$ for initial conditions $x(0) = 1$ and $x'(0) =
+Solve $x''' + x = (t-1)^3 u(t-1)$ for initial conditions $x(0) = 1$ and $x'(0) =
 0$, $x''(0) = 0$.
 \end{exercise}
+\exsol{%
+$x(t)=u(t-1)\left[(t-1)^3+4e^{(t-1)/2}\cos\left(\frac{\sqrt{3}}{2}(t-1)\right)+6+2e^{-(t-1)}\right]+\frac{1}{3}e^{t/2}\cos(\frac{\sqrt{3}}{2}t)+\frac{1}{3}e^{-t}$
+}
 
-\begin{exercise}
+\begin{exercise}2qw3q
 	Solve $x''-x = (t^2-1) u(t-1)$ for initial conditions $x(0)=1$, $x'(0) = 2$
 	using the Laplace transform.
 \end{exercise}
@@ -1105,6 +1150,21 @@ Show the second shifting property:
 $\mathcal{L} \bigl\{ f(t-a) \, u(t-a) \bigr\}
 = e^{-as} \mathcal{L} \bigl\{ f(t) \bigr\}$.
 \end{exercise}
+\exsolution{%
+Using the definition
+\begin{align*}
+\mathcal{L} \bigl\{ f(t-a)u(t-a) \bigr\} =&\int_0^\infty e^{-st}f(t-a)u(t-a)dt \\
+=& \int_a^\infty e^{-st}f(t-a)dt 
+\end{align*}
+Defining $\tau\equiv t-a$ we get
+\begin{align*}
+\int_0^\infty e^{-as}e^{-s\tau}f(\tau)d\tau=e^{-as}\underbrace{\int_0^\infty e^{-s\tau}f(\tau)}_{F(s)}d\tau
+\end{align*}
+Therefore
+\begin{align*}
+\mathcal{L} \bigl\{ f(t-a)u(t-a) \bigr\} = e^{-as}\mathcal{L}\bigl\{ f(t) \bigr\}
+\end{align*}
+}
 
 \begin{exercise}
 Let us think of the mass-spring system with a rocket from
@@ -1122,6 +1182,27 @@ for which the rocket fires and the resulting oscillation
 has amplitude 0 (the mass is not moving)?
 \end{tasks}
 \end{exercise}
+\exsolution{%
+a) From the example
+\begin{align*}
+x(t)=(1-\cos(t-1))u(t-1)-(1-\cos(t-5))u(t-5)
+\end{align*}
+At $t>5$ 
+\begin{align*}
+x(t)=& \cos(t-5)-\cos(t-1) \\
+=& \underbrace{2\sin\left(\frac{5-1}{2} \right)}_{A}\sin\left( t-\frac{5+1}{2}\right)
+\end{align*}
+Where $|A|\approx 1.81$ is the amplitude. Defining $t_f$ as the time the rocket stops firing, and $t_0=t_f-1$ as the duration the rocket fires, we can generalize this result
+\begin{align*}
+x(t)=2\sin\left( \frac{t_0}{2}\right)\sin\left( t-\frac{t_0+2}{2} \right)
+\end{align*}
+So the amplitude is given by 
+\begin{align*}
+A(t_0)=2\lvert \sin(t_0/2)\rvert
+\end{align*}
+\\
+b) From $A(t_0)=2\lvert \sin(t_0/2)\rvert$ this is zero when $t_0=2n\pi$ for $n$ a positive integer. 
+}
 
 \begin{exercise}
 Define
@@ -1139,6 +1220,11 @@ f(t) =
 \task Solve $x''+x=f(t)$, $x(0)=0$, $x'(0) = 0$ using Laplace transform.
 \end{tasks}
 \end{exercise}
+\exsol{%
+b) $u(t-1)(t-1)^2+u(t-2)\left((3-t)-(t-1)^2\right)-u(t-3)(t-3)$
+\\
+c) $x(t)=u(t-1)\bigl[(t-1)^2-2+2\cos(t-1)\bigr]+u(t-2)\bigl[-t^2+t+4+3\sin(t-2)-2\cos(t-2)\bigr]-u(t-3)\bigl[(t-3)-\sin(t-3)\bigr]$
+}
 
 \begin{exercise}
 	Using the Heaviside function $u(t)$, write down the function
@@ -1171,6 +1257,16 @@ Find the transfer function for
 $m x'' + c x' + kx = f(t)$
 (assuming the initial conditions are zero).
 \end{exercise}
+\exsolution{%
+Taking the Laplace transform
+\begin{align*}
+ms^2X+csX+kX=F(s)
+\end{align*}
+The transfer function is 
+\begin{align*}
+H(s)=\frac{X}{F}=\frac{1}{ms^2+cs+k}
+\end{align*}
+}
 
 
 \begin{exercise}
@@ -1181,6 +1277,12 @@ $m x'' + c x' + kx = f(t)$
 	\end{equation*}
 	Hint: Differentiate under the integral sign.
 \end{exercise}
+\exsolution{%
+\begin{align*}
+F'(s)=&\frac{dF(s)}{ds}=\frac{d}{ds}\int_0^\infty f(t)e^{-st}dt=\int_0^\infty f(t)\frac{d}{ds}e^{-st}dt=\int_0^\infty \underbrace{\left[ -tf(t) \right]}_{\textrm{call this } g(t)}e^{-st}dt \\
+=& \int_0^\infty g(t) e^{-st} dt=\mathcal{L}\{ g(t)\}=\mathcal{L} \{ -tf(t)\}
+\end{align*}
+}
 
 \begin{exercise}
 	Find the Laplace transform of $f(t)=t\sin(3t)$
@@ -1513,11 +1615,20 @@ x(t) = \cosh \bigl( \sqrt{2} \, t \bigr) -
 Let $f(t) = t^2$ for $t \geq 0$, and $g(t) = u(t-1)$.  Compute
 $f * g$.
 \end{exercise}
+\exsolution{%
+\begin{align*}
+f*g =& \int_0^t \tau^2 u(t-\tau-1) d\tau	  \\
+=& \int_0^{t-1}\tau^2 d\tau  = \frac{1}{3}(t-1)^3
+\end{align*}
+}
 
 \begin{exercise}
 Let $f(t) = t$ for $t \geq 0$, and $g(t) = \sin t $ for $t \geq 0$.  Compute
 $f * g$.
 \end{exercise}
+\exsol{%
+$ t-\sin(t)$
+}
 
 \begin{exercise}
 	Let $f(t) = \cos t$ for $t \geq 0$, and $g(t) = e^{-t}$.  Compute
@@ -1536,6 +1647,23 @@ for an arbitrary function $f(t)$, where $m > 0$, $c > 0$, $k > 0$,
 and $c^2 - 4km > 0$ (the system is overdamped).
 Write the solution as a definite integral.
 \end{exercise}
+\exsolution{%
+Taking the Laplace transform
+\begin{align*}
+ms^2X+csX+kX=& F(s) \\
+X=& F(s)\underbrace{ \frac{1}{ms^2+cs+k}}_{G(s)} \\
+G =& \frac{1}{m}\frac{1}{(s+\frac{c}{2m})^2+\frac{k}{m}-\frac{c^2}{4m^2}}= \frac{1}{m}\frac{1}{(s+\frac{c}{2m})^2-\left(\frac{\sqrt{c^2-4km}}{2m}\right)^2}=\frac{1}{m\omega}\frac{\omega}{(s+\frac{c}{2m})^2-\omega^2}
+\end{align*}
+Where we defined $\omega\equiv \frac{\sqrt{c^2-4km}}{2m}>0$.  We can now find $g(t)$ using the shifting property
+\begin{align*}
+g(t) = \frac{1}{m\omega}e^{-\frac{c}{2m}t}\sinh(\omega t)
+\end{align*}
+And finally using convolution 
+\begin{align*}
+x(t)=\int_0^t f(\tau) \frac{1}{m\omega}e^{-\frac{c}{2m}(t-\tau)}\sinh(\omega (t-\tau))d\tau
+\end{align*}
+}
+
 
 \begin{exercise}
 Find the solution to
@@ -1546,6 +1674,9 @@ for an arbitrary function $f(t)$, where $m > 0$, $c > 0$, $k > 0$,
 and $c^2 - 4km < 0$ (the system is underdamped).
 Write the solution as a definite integral.
 \end{exercise}
+\exsol{%
+$x(t)=\int_0^t f(\tau) \frac{1}{m\omega}e^{-\frac{c}{2m}(t-\tau)}\sin(\omega (t-\tau))d\tau$
+}
 
 \begin{exercise}
 Find the solution to
@@ -1556,6 +1687,9 @@ for an arbitrary function $f(t)$, where $m > 0$, $c > 0$, $k > 0$,
 and $c^2 = 4km$ (the system is critically damped).
 Write the solution as a definite integral.
 \end{exercise}
+\exsol{%
+$x(t)=\int_0^t f(\tau) \frac{1}{m}e^{-\frac{c}{2m}(t-\tau)}d\tau$
+}
 
 \begin{exercise}
 	Solve $x''+x = \sin t$, $x(0) = 0$, $x'(0)=0$ using convolution.
@@ -1577,7 +1711,7 @@ Write the solution as a definite integral.
 \end{exercise}
 \exsolution{Using the property of derivatives of the transform and the Convolution property, we write
 	\[\mathcal{L}\left[t\int_0^t \cos(t-\tau) sin(\tau) ~ d\tau\right]=-\frac{d}{ds}\mathcal{L}\left[\int_0^t \cos(t-\tau) sin(\tau) ~ d\tau\right]=-\frac{d}{ds}\left[\mathcal{L}(\cos t)\cdot\mathcal{L}(\sin t)\right]\]
-	\[\hspace*{5in}=-\frac{d}{ds}\left[\frac{s}{(s^{2}+1)}\right]=\frac{3 s^2-1}{\left(s^2+1\right)^3}\]
+	\[=-\frac{d}{ds}\left[\frac{s}{(s^{2}+1)}\right]=\frac{3 s^2-1}{\left(s^2+1\right)^3}\]
 }
 
 \begin{exercise}
@@ -1593,6 +1727,19 @@ Write the solution as a definite integral.
 	definite integral.  Hint: Do not try to compute the
 	Laplace transform of $e^{-t^2}$.
 \end{exercise}
+\exsolution{%
+Taking the Laplace transform of the equation
+\begin{align*}
+s^2X-2X=&L\left\{ e^{-t^2} \right\}=F(s) \\
+X=& F(s) \underbrace{\frac{1}{s^2-2}}_{G(s)} \\
+G(s) =& \frac{1}{\sqrt{2}}\frac{\sqrt{2}}{s^2-(\sqrt{2})^2} \rightarrow \\
+g(t) =& \frac{1}{\sqrt{2}}\sinh(\sqrt{2}t)
+\end{align*}
+So using the convolution property 
+\begin{align*}
+x(t)=\int_0^t e^{-\tau^2}\frac{1}{\sqrt{2}}\sinh(\sqrt{2}(t-\tau))d\tau
+\end{align*}
+}
 
 \begin{exercise}
 Solve
@@ -1600,6 +1747,16 @@ Solve
 x(t) =  e^{-t} + \int_0^t \cos(t-\tau) x(\tau) ~ d\tau .
 \end{equation*}
 \end{exercise}
+\exsolution{%
+Taking the Laplace transform of the equation and solving for $X$
+\begin{align*}
+X=\frac{1}{s+1}\frac{s^2+1}{s^2-s+1}
+\end{align*}
+Splitting the fraction and completing the square, this gives
+\begin{align*}
+x(t)=\frac{1}{\sqrt{3}}e^{t/2}\sin\left( \frac{\sqrt{3}}{2}t\right) + \frac{1}{3}e^{t/2}\cos\left( \frac{\sqrt{3}}{2}t\right) +\frac{2}{3}e^{-t}
+\end{align*}
+}
 
 \begin{exercise}
 Solve
@@ -1607,6 +1764,9 @@ Solve
 x(t) =  \cos t + \int_0^t \cos(t-\tau) x(\tau) ~ d\tau .
 \end{equation*}
 \end{exercise}
+\exsol{%
+$x(t)=\frac{1}{\sqrt{3}}e^{t/2}\sin\left( \frac{\sqrt{3}}{2}t\right)+e^{t/2}\cos\left( \frac{\sqrt{3}}{2}t\right)$
+}
 
 \begin{exercise}
 Compute ${\mathcal{L}}^{-1} \left\{ \frac{s}{{(s^2+4)}^2} \right\}$ using
@@ -2061,6 +2221,37 @@ y(x) = \frac{-{(x-1)}^3}{6} u(x-1) - \frac{x}{4} + \frac{x^3}{12} .
 \end{example}
 
 \subsection{Exercises}
+
+\begin{exercise}
+	Compute
+	${\mathcal{L}}^{-1} \left\{ \frac{s^2}{s^2+1} \right\}$.
+\end{exercise}
+\exsolution{Re-writing the given expression as:
+	\begin{equation}\frac{s^{2}}{s^{2}+1}=\frac{s^{2}+1-1}{s^{2}+1}=1-\frac{1}{s^{2}+1}\nonumber\end{equation}
+	Applying the inverse transform, we can get
+	\begin{equation}{\mathcal{L}}^{-1} \left\{ \frac{s^2}{s^2+1} \right\}=\delta(t) - \sin(t)\nonumber\end{equation}
+}
+%1 - 1/(s^2+1)
+
+
+\begin{exercise}
+	Compute
+	${\mathcal{L}}^{-1} \left\{ \frac{3 s^2 e^{-s} + 2}{s^2} \right\}$.
+\end{exercise}
+\exsol{%
+	$3 \delta(t-1) + 2 t$
+}
+
+
+\begin{exercise}
+Compute
+${\mathcal{L}}^{-1} \left\{ \frac{s^2+s+1}{s^2} \right\}$.
+\end{exercise}
+\exsol{%
+$\delta(t)+1+t $
+}
+
+
 \begin{exercise}
 	Solve (find the impulse response)
 	$x' + a x = \delta(t)$, $x(0) = 0$.
@@ -2074,19 +2265,41 @@ Applying the inverse Laplace transform, we get
 }
 %$sX+aX = 1$
 %$X = \frac{1}{s+a}$
+
+
 \begin{exercise}
 Solve (find the impulse response)
 $x'' + x' + x = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
 \end{exercise}
+\exsol{%
+$x(t)=\frac{2}{\sqrt{3}}e^{-t/2}\sin \left (\frac{\sqrt{3}}{2}t\right)$
+}
+
+
 \begin{exercise}
 Solve (find the impulse response)
 $x'' + 2 x' + x = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
 \end{exercise}
+\exsol{%
+$x(t)=te^{-t}$
+}
+
+
 \begin{exercise}
 A pulse can come later and can be bigger.
 Solve 
 $x'' + 4 x = 4\delta(t-1)$, $x(0) = 0$, $x'(0)=0$.
 \end{exercise}
+\exsolution{%
+Taking the Laplace transform 
+\begin{align*}
+s^2X+4X=& 4e^{-s} \\
+X =& 2e^{-s}\frac{2}{s^2+2^2} \\
+x(t) =& 2u(t-1) \sin\left( 2(t-1)\right)
+\end{align*}
+}
+
+
 \begin{exercise}
 	Solve (find the impulse response)
 	$x'' = \delta(t)$, $x(0) = 0$, $x'(0)=0$.
@@ -2094,9 +2307,30 @@ $x'' + 4 x = 4\delta(t-1)$, $x(0) = 0$, $x'(0)=0$.
 \exsol{%
 	$x(t) = t$
 }
+
+
 \begin{exercise}[challenging]
 	Solve \exampleref{lt:examplebeam} via integrating 4 times in the $x$ variable.
 \end{exercise}
+\exsolution{%
+Integrating twice
+\begin{align*}
+y^{(3)}(x)+C_1=& -u(x-1) \\
+y''(x)+C_1x+C_2=&-u(x-1)(x-1)
+\end{align*}
+Applying initial conditions we find that $C_1=0$ and $C_2=-\frac{1}{2}$. Integrating twice again
+\begin{align*}
+y'(x)-\frac{x^2}{4}+C_3=& -\frac{1}{2} u(x-1)(x-1)^2 \\
+y(x)-\frac{x^3}{12}+C_3+C_4=& -u(x-1) \frac{(x-1)^3}{6}
+\end{align*}
+Applying the other initial conditions we find that $C_4=0$ and $C_3=\frac{1}{4}$. Solving for $y(x)$
+\begin{align*}
+y(x)=\frac{x^3}{12}-\frac{x}{4}-u(x-1)\frac{(x-1)^3}{3}
+\end{align*}
+}
+
+
+
 \begin{exercise}
 	Suppose that $L x = \delta(t)$, $x(0) = 0$, $x'(0) = 0$, has the solution
 	$x(t) = \cos(t)$ for $t > 0$.  Find (in closed form) the solution to
@@ -2105,32 +2339,19 @@ $x'' + 4 x = 4\delta(t-1)$, $x(0) = 0$, $x'(0)=0$.
 \exsolution{Taking the Laplace transform of $L x = \delta(t)$, we can write that $F(s)X(s)=1$ or $X(s)=\frac{1}{F(s)}$. We are given that when we take the inverse Laplace, we get $x(t)=\cos t$ implying that $\mathcal{L}^{-1}\left[1/F(s)\right]=\cos t$. Now, taking the Laplace transform of $Lx=\sin t$. This results in $X(s)=\frac{1}{F(s)}\cdot\frac{1}{s^{2}+1}$. Using the inverse Laplace, we get
 	$x(t) = \cos(t)*\sin(t) = \frac{1}{2} t \sin(t)$
 }
+
+
 \begin{exercise}
 	Suppose that $L x = \delta(t)$, $x(0) = 0$, $x'(0) = 0$, has the solution
 	$x = e^{-t}$ for $t > 0$.  Find the solution to
 	$Lx = t^2$, $x(0) = 0$, $x'(0) = 0$ for $t > 0$.
 \end{exercise}
-\begin{exercise}
-	Compute
-	${\mathcal{L}}^{-1} \left\{ \frac{s^2}{s^2+1} \right\}$.
-\end{exercise}
-\exsolution{Re-writing the given expression as:
-	\begin{equation}\frac{s^{2}}{s^{2}+1}=\frac{s^{2}+1-1}{s^{2}+1}=1-\frac{1}{s^{2}+1}\nonumber\end{equation}
-	Applying the inverse transform, we can get
-	\begin{equation}{\mathcal{L}}^{-1} \left\{ \frac{s^2}{s^2+1} \right\}=\delta(t) - \sin(t)\nonumber\end{equation}
-}
-%1 - 1/(s^2+1)
-\begin{exercise}
-	Compute
-	${\mathcal{L}}^{-1} \left\{ \frac{3 s^2 e^{-s} + 2}{s^2} \right\}$.
-\end{exercise}
 \exsol{%
-	$3 \delta(t-1) + 2 t$
+$x(t)=t^2-2t-2e^{-t}+2$
 }
-\begin{exercise}
-Compute
-${\mathcal{L}}^{-1} \left\{ \frac{s^2+s+1}{s^2} \right\}$.
-\end{exercise}
+
+
+
 \begin{exercise}
 	Suppose that $f(t)$ and $g(t)$ are differentiable functions
 	and suppose that $f(t) = g(t) = 0$ for all $t \leq 0$.  Show that
@@ -2138,12 +2359,55 @@ ${\mathcal{L}}^{-1} \left\{ \frac{s^2+s+1}{s^2} \right\}$.
 	(f * g)'(t) = (f' * g)(t) = (f * g')(t) .
 	\end{equation*}
 \end{exercise}
+\exsolution{%
+Consider 
+\begin{align*}
+(f*g)'(t)=\frac{d}{dt}\int_0^t f(\tau)g(t-\tau)d\tau = \frac{d}{dt} h(t)
+\end{align*}
+Where $h(t)\equiv (f*g)(t)$. Taking the Laplace transform 
+\begin{align*}
+\mathcal{L}\{(f*g)'(t)\}=sH(s)-h(0)=sF(s)G(s)
+\end{align*}
+Now consider
+\begin{align*}
+\mathcal{L}\{ (f'*g)(t) \}=\mathcal{L}\{ f'\} \mathcal{L} \{ g\}=sF(s)G(s)
+\end{align*}
+And finally 
+\begin{align*}
+\mathcal{L}\{ (f*g')(t) \}=\mathcal{L}\{ f\} \mathcal{L} \{ g'\}=sF(s)G(s)
+\end{align*}
+By the uniqueness of the Laplace transform then 
+\begin{align*}
+(f*g)'(t)= (f'*g)(t) = (f*g')(t)
+\end{align*}
+}
+
+
 \begin{exercise}
 Suppose we have a beam of length $1$ simply supported at the ends and
 suppose that force $F=1$ is applied at $x=\frac{3}{4}$ in the downward
 direction.  Suppose that $EI=1$ for simplicity.  Find the beam deflection
 $y(x)$.
 \end{exercise}
+\exsolution{%
+The deflection equation is 
+\begin{align*}
+\frac{d^4y}{d^4x}=-\delta \left( x-\frac{3}{4}\right)
+\end{align*}
+With the boundary conditions $y(0)=y(1)=0$ and $y''(0)=y''(1)=0$.
+Taking the Laplace transform and solving for $Y$
+\begin{align*}
+Y=& -\frac{e^{-3s/4}}{s^3}+\frac{C_1}{s^2}+\frac{C_2}{s^4} \\
+y(x) =& -\frac{(x-3/4)^3}{6}u(x-3/4)+C_1x+C_2\frac{x^3}{6}
+\end{align*}
+Where the boundary conditions $y(0)=0$ and $y''(0)=0$ were applied, and we defined $y'(0)=C_1$  and $y'''(0)=C_2$
+Applying the other boundary conditions we find that $C_1=-\frac{5}{128}$ and $C_2=\frac{1}{4}$. Therefore
+\begin{align*}
+y(x)=\frac{(x-3/4)^3}{6}u(x-3/4)-\frac{5}{128}x+\frac{1}{24}x^3
+\end{align*}
+}
+
+
 %\noindent\textbf{Transform of Periodic Functions:} Given that we have a function $f(t)$ which is piecewise continuous on $[0,\infty)]$, periodic with period $T$ ($f(t+T)=f(t)$), and is of exponential order as well. Then, for $s>0$, we can show that:
 %\begin{equation}
 %\mathcal{L}[f(t)]=\frac{1}{1-e^{-sT}}\int_{0}^{T}e^{-st}f(t)dt.

--- a/ch-laplace.tex
+++ b/ch-laplace.tex
@@ -553,15 +553,15 @@ t & \text{if } \; t \geq 1, \\
 \end{exercise}
 \exsolution{%
 Using the definition of the laplace tranform (and the fact that $f(t)$ is non-zero only between 0 and 1):\\\\
-$\mathcal{L}[f(t)]=\int_{0}^{1}te^{-st}dt=\frac{1-e^{-s} (s+1)}{s^2}$
+$\mathcal{L}[f(t)]=\int_{1}^{\infty}te^{-st}dt=e^{-s}(\frac{1}{s}+\frac{1}{s^2})$
 }
 
-\begin{exercise}
-	Find the Laplace transform of the function whose graph is given below:
-\end{exercise}
-\exsol{%
-$\frac{-1+e^{-s} (s+1)}{s^2}$
-}
+%\begin{exercise}
+%	Find the Laplace transform of the function whose graph is given below:
+%\end{exercise}
+%\exsol{%
+%$\frac{-1+e^{-s} (s+1)}{s^2}$
+%}
 
 \begin{exercise}
 Find the inverse Laplace transform of $\frac{1}{{(s-1)}^2(s+1)}$.
@@ -890,7 +890,7 @@ The plot of this solution is given in \figurevref{lt:heavisideexfig}.
 \end{myfig}
 \end{example}
 
-\begin{video}[SpLHM16mFt][Solving an IVP with a piecewise nonhomogeneity ][la-piecewise2]
+\begin{video}[SpLHM16mFtI][Solving an IVP with a piecewise nonhomogeneity ][la-piecewise2]
 	This video is a start to finish walkthrough of the process of going from an IVP, converting via Laplace, dealing with the piecewise part, and then converting back to a solution to the original IVP. This video thus includes many pieces we've been developing so is probably your best check for comprehension yet. Feel free to try and work it out on your own first and skip to the end to check the solution. 
 
 	\emph{TYPO: At about 4:00, in the red, $\mathcal{L}\{u(t-a)f(t-a)\}=e^{-as}\mathcal{L}\{f(t)\}$. I wrote the exponential with a t not an s. This typo persists in a few places in the video}
@@ -1137,7 +1137,7 @@ Solve $x''' + x = (t-1)^3 u(t-1)$ for initial conditions $x(0) = 1$ and $x'(0) =
 $x(t)=u(t-1)\left[(t-1)^3+4e^{(t-1)/2}\cos\left(\frac{\sqrt{3}}{2}(t-1)\right)+6+2e^{-(t-1)}\right]+\frac{1}{3}e^{t/2}\cos(\frac{\sqrt{3}}{2}t)+\frac{1}{3}e^{-t}$
 }
 
-\begin{exercise}2qw3q
+\begin{exercise}
 	Solve $x''-x = (t^2-1) u(t-1)$ for initial conditions $x(0)=1$, $x'(0) = 2$
 	using the Laplace transform.
 \end{exercise}
@@ -2113,6 +2113,19 @@ the impulse response and the input $f(t)$.
 
 	\emph{TYPO: The formula is $\mathcal{L}\{\delta_a(t)\}=e^{-as}$. In several places in the video I drop the negative sign.}
 \end{video}
+
+\begin{example}
+	\emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/wzhdm4be}{this Geogebra applet} to explore the behaviour of a damped oscillator with a periodic impulse input $F(t)=F_0\delta_p(t)$. Explore how different the behaviour becomes under certain periods or amplitudes. A few examples of interesting behaviours:
+	\begin{itemize}
+	\item Reproduce the response shown in Video 3.4.3.
+	\item  With some minor modifications, this ODE could describe a pendulum with friction, e.g. a swing. How often do you need to apply a push (the impulse) to maximize the amplitude? 
+	\item Notice what happens when you set $p$ to be very small. What is behaviour similar to?  
+	\end{itemize}
+	
+  
+  
+  
+	\end{example}
 
 
 

--- a/ch-power-ser.tex
+++ b/ch-power-ser.tex
@@ -5,8 +5,7 @@
 \section{Power series}
 \label{powerseries:section}
 
-\sectionnotes{1 or 1.5 lecture\EPref{, \S8.1 in \cite{EP}}\BDref{,
-\S5.1 in \cite{BD}}}
+
 
 Many functions can be written in terms of a power series
 \begin{equation*}
@@ -622,8 +621,9 @@ $f(x)-g(x)$ is a polynomial.  Hint: Use Taylor series.
 \section{Series solutions of linear second order ODEs}
 \label{seriessols:section}
 
-\sectionnotes{1 or 1.5 lecture\EPref{, \S8.2 in \cite{EP}}\BDref{,
-\S5.2 and \S5.3 in \cite{BD}}}
+\begin{video}[vX9-z9RrAtc][Intro to Series Solutions][seriesintro]
+	In this video we introduce the idea of solving an ODE using a series solution. We will see how to form and solve a recurrence relation and then test for convergence of the resulting series.
+\end{video}
 
 Suppose we have a linear second order homogeneous ODE of the form
 \begin{equation*}
@@ -756,6 +756,10 @@ Of course, in general we will not be able to recognize
 the series that appears, since usually there will not be
 any elementary function that matches it.  In that case we will be
 content with the series.
+
+\begin{video}[dCRDUX2ahjM][Example: Airy's Equation][seriesAiry]
+We do a full example of a slightly more complicated example: Airy's Equation
+\end{video}
 
 \begin{example}
 Let us do a more complex example.  Consider
@@ -1011,6 +1015,10 @@ y_1(x) = 1 + \frac{2(-4)}{2!} x^2 + \frac{2^2(-4)(2-4)}{4!} x^4
 = 1 - 4x^2 + \frac{4}{3} x^4 .
 \end{equation*}
 \end{example}
+
+\begin{video}[vJDXrIB5CGQ][Theory of Series solutions][seriestheory]
+	When do series solutions exist? In this video we develop a bit of the theory. This will be extended quite a bit if you take Math 342 in the future where we will talk about how to deal with singular points. For now, we'll focus on ordinary points. 
+\end{video}
 
 \subsection{Exercises}
 

--- a/ch-power-ser.tex
+++ b/ch-power-ser.tex
@@ -513,61 +513,37 @@ x + \sum_{k=0}^\infty {(-1)}^k x^k - \sum_{k=0}^\infty x^k
 Is the power series $\displaystyle \sum_{k=0}^\infty e^k x^k$ convergent?
 If so, what is the radius of convergence?
 \end{exercise}
+\exsolution{%
+By the ratio test 
+\begin{align*}
+A=\lim_{k \to \infty}\left \lvert \frac{e^{k+1}}{e^k}\right \rvert = e
+\end{align*}
+So the series is convergent with a radius of convergence $\rho=1/e$.
+}
 
 \begin{exercise}
 Is the power series $\displaystyle \sum_{k=0}^\infty k x^k$ convergent?
 If so, what is the radius of convergence?
 \end{exercise}
+\exsol{%
+Yes. Radius of convergence is 1.
+}
 
 \begin{exercise}
 Is the power series $\displaystyle \sum_{k=0}^\infty k! x^k$ convergent?
 If so, what is the radius of convergence?
 \end{exercise}
+\exsol{%
+Yes. Radius of convergence is 0 (only converges if $x=0$).
+}
 
 \begin{exercise}
 Is the power series $\displaystyle \sum_{k=0}^\infty \frac{1}{(2k)!} {(x-10)}^k$
 convergent?  If so, what is the radius of convergence?
 \end{exercise}
-
-\begin{exercise}
-Determine the Taylor series for $\sin x$ around the point $x_0 = \pi$.
-\end{exercise}
-
-\begin{exercise}
-Determine the Taylor series for $\ln x$ around the point $x_0 = 1$,
-and find the radius of convergence.
-\end{exercise}
-
-\begin{exercise}
-Determine the Taylor series
-and its radius of convergence of $\dfrac{1}{1+x}$
-around $x_0 = 0$.
-\end{exercise}
-
-\begin{exercise}
-Determine the Taylor series and its radius of convergence
-of
-$\dfrac{x}{4-x^2}$ around $x_0 = 0$.  Hint: You will not be able to
-use the ratio test.
-\end{exercise}
-
-\begin{exercise}
-Expand $x^5+5x+1$ as a power series around $x_0 = 5$.
-\end{exercise}
-
-\begin{exercise}
-Suppose that the ratio test applies to a series
-$\displaystyle \sum_{k=0}^\infty a_k x^k$.  Show, using the ratio
-test, that the radius of convergence of the differentiated
-series is the same as that of the original series.
-\end{exercise}
-
-\begin{exercise}
-Suppose that $f$ is an analytic function such that
-$f^{(n)}(0) = n$.  Find $f(1)$.
-\end{exercise}
-
-\setcounter{exercise}{100}
+\exsol{%
+Yes. Radius of convergence is $\infty$.
+}
 
 \begin{exercise}
 Is the power series
@@ -578,6 +554,7 @@ convergent? If so, what is the radius of convergence?
 Yes.  Radius of convergence is $10$.
 }
 
+
 \begin{exercise}[challenging]
 Is the power series
 $\displaystyle \sum_{n=1}^\infty \frac{n!}{n^n} x^n$
@@ -585,6 +562,66 @@ convergent? If so, what is the radius of convergence?
 \end{exercise}
 \exsol{%
 Yes.  Radius of convergence is $e$.
+}
+
+\begin{exercise}
+Determine the Taylor series for $\sin x$ around the point $x_0 = \pi$.
+\end{exercise}
+\exsolution{%
+The Taylor series at $x_0=\pi$ is give by
+\begin{align*}
+\sum_{k=0}^{\infty}\frac{f^{(k)}(\pi)}{k!}(x-\pi)^k=0+(-1)(x-\pi)+0+\frac{1}{3!}(x-\pi)^3+0+\frac{-1}{5!}(x-\pi)^5+...=\sum_{k=0}^\infty\frac{(-1)^{k+1}(x-\pi)^{2k+1}}{(2k+1)!}
+\end{align*}
+}
+
+\begin{exercise}
+Determine the Taylor series for $\ln x$ around the point $x_0 = 1$,
+and find the radius of convergence.
+\end{exercise}
+\exsol{%
+$\sum_{k=1}^\infty\frac{(-1)^{k+1}(x-1)^k}{k}$. The radius of convergence is 1 (series also converges if x=2). 
+}
+
+\begin{exercise}
+Determine the Taylor series
+and its radius of convergence of $\dfrac{1}{1+x}$
+around $x_0 = 0$.
+\end{exercise}
+\exsol{%
+$\sum_{k=0}^\infty(-1)^kx^k$. The radius of convergence is 1.
+}
+
+\begin{exercise}
+Determine the Taylor series and its radius of convergence
+of
+$\dfrac{x}{4-x^2}$ around $x_0 = 0$.  Hint: You will not be able to
+use the ratio test.
+\end{exercise}
+\exsolution{%
+We can rewrite the expression as
+\begin{align*}
+\frac{x}{4}\frac{1}{1-(x/2)^2}=\frac{x}{4}\sum_{k=0}^{\infty}\left(\frac{x}{2}\right)^{2k}=\sum_{k=0}^\infty\frac{x^{2k+1}}{2^{2k+2}}
+\end{align*}
+To find the radius of convergence 
+\begin{align*}
+A=\lim_{k\to \infty}\frac{1/4^{k+2}}{1/4^{k+1}}=\frac{1}{4}
+\end{align*}
+So the radius of convergence is 4.
+}
+
+\begin{exercise}
+Expand $x^5+5x+1$ as a power series around $x_0 = 5$.
+\end{exercise}
+\exsol{%
+$51+15(x-5)+\frac{2}{2!}(x-5)^2$ (note that this gives back the original polynomial).
+}
+
+\begin{exercise}[challenging]
+Find the Taylor series for $x^7 e^x$ around $x_0 = 0$.
+\end{exercise}
+\exsol{%
+$\sum\limits_{n=7}^\infty
+\frac{1}{(n-7)!} x^n$
 }
 
 \begin{exercise}
@@ -598,13 +635,44 @@ $\frac{1}{1-x} =
 which converges for $1 < x < 3$.
 }
 
-\begin{exercise}[challenging]
-Find the Taylor series for $x^7 e^x$ around $x_0 = 0$.
+\begin{exercise}
+Suppose that the ratio test applies to a series
+$\displaystyle \sum_{k=0}^\infty a_k x^k$.  Show, using the ratio
+test, that the radius of convergence of the differentiated
+series is the same as that of the original series.
 \end{exercise}
-\exsol{%
-$\sum\limits_{n=7}^\infty
-\frac{1}{(n-7)!} x^n$
+\exsolution{%
+Applying the ratio test to the series
+\begin{align*}
+A=\lim_{k\to \infty}\left \lvert\frac{a_{k+1}}{a_k} \right\rvert 
+\end{align*}
+Taking the derivative of the series we get 
+\begin{align*}
+\rightarrow \sum_{k=1}^\infty ka_kx^{k-1}
+\end{align*}
+Applying the ratio test
+\begin{align*}
+A=\lim_{k\to \infty}\left\lvert\frac{(k+1)a_{k+1}}{ka_k}\right \rvert=\lim_{k\to \infty}\frac{k+1}{k} \lim_{k\to \infty}\left\lvert \frac{a_k+1}{a_k}\right \rvert=\lim_{k\to \infty}\left \lvert\frac{a_{k+1}}{a_k} \right\rvert =A
+\end{align*}
+So the radius of convergence is the same. 
 }
+
+\begin{exercise}
+Suppose that $f$ is an analytic function such that
+$f^{(n)}(0) = n$.  Find $f(1)$.
+\end{exercise}
+\exsolution{%
+Since it's an analytic function, near $x=0$
+\begin{align*}
+f(x)&=f(0)+f'(0)x+\frac{1}{2!} f''(0)x^2+\frac{1}{3!}f'''(0)x^3+... \\
+&=0+x+\frac{1}{2!} x^2+\frac{1}{3!}x^3 = \sum_{k=1}^\infty \frac{x^k}{k!}
+\end{align*}
+At $x=1$
+\begin{align*}
+f(1)= \sum_{k=1}^{\infty}\frac{1}{k!}= \sum_{k=0}^{\infty}\frac{1}{k!}-1=e-1
+\end{align*}
+}
+
 
 \begin{exercise}[challenging]
 Imagine $f$ and $g$ are analytic functions such that
@@ -1029,48 +1097,68 @@ and if possible find a general formula for the $k^{\text{th}}$ coefficient.
 \begin{exercise}
 Use power series methods to solve $y''+y = 0$ at the point $x_0 = 1$.
 \end{exercise}
+\exsolution{%
+\begin{align*}
+y=& \sum_{k=0}^{\infty}a_k(x-1)^k \\
+y''=& \sum_{k=2}^\infty k(k-1)a_k(x-1)^{k-2},\quad \rm (k\rightarrow k+2) \\
+=& \sum_{k=0}^\infty (k+2)(k+1)a_{k+2}(x-1)^{k}
+\end{align*}
+Plugging into the ODE
+\begin{align*}
+&\sum_{k=0}^\infty (k+2)(k+1)a_{k+2}(x-1)^{k} +  \sum_{k=0}^{\infty}a_k(x-1)^k = 0 \\
+&\rightarrow (k+2)(k+1)a_{k+2}+a_k=0 \\
+&a_{k+2}=-\frac{a_k}{(k+2)(k+1)} \\
+&a_2=-\frac{a_0}{2},\quad a_3=-\frac{a_1}{2\times3},\quad a_4=\frac{(-1)^2a_0}{4!} \\
+&a_5=\frac{(-1)^2a_1}{5!},\quad a_6=\frac{(-1)^3a_0}{6!},\quad a_7=\frac{(-1)^3a_1}{7!}\quad ...
+\end{align*}
+We can note that for even $k$:
+\begin{align*}
+a_k=a_{2n}=\frac{(-1)^na_0}{(2n)!}
+\end{align*}
+And for odd $k$:
+\begin{align*}
+a_k=a_{2n+1}=\frac{(-1)^na_1}{(2n+1)!}
+\end{align*}
+So the solution can be written as
+\begin{align*}
+y=a_0\sum_{n=0}^\infty \frac{(-1)^n}{(2n)!}(x-1)^{2n}+a_1\sum_{n=0}^\infty \frac{(-1)^n}{(2n+1)!}(x-1)^{2n+1}=a_0\cos(x-1)+a_1\sin(x-1)
+\end{align*}
+}
 
 \begin{exercise}
 Use power series methods to solve $y''+4xy = 0$ at the point $x_0 = 0$.
 \end{exercise}
+\exsol{%
+The solution can be written as $y=a_0y_0+a_1y_1$, where
+\begin{align*}
+y_0=& 1+\frac{(-4)}{(2)(3)}x^3+\frac{(-4)^2}{(2)(3)(5)(6)}x^6+...+\frac{(-4)^n}{(2)(3)(5)(6)...(3n-1)(3n)}x^{3n}+... \\
+y_1=& x+\frac{(-4)}{(3)(4)}x^4+\frac{(-4)^2}{(3)(4)(6)(7)}x^7+...+\frac{(-4)^n}{(3)(4)(6)(7)...(3n)(3n+1)}x^{3n+1}+...
+\end{align*}
+}
 
 \begin{exercise}
 Use power series methods to solve $y''-xy = 0$ at the point $x_0 = 1$.
 \end{exercise}
+\exsol{%
+Note: See Example 1.2.2. 
+The solution can be written as $y=a_0y_0+a_1y_1$, where
+\begin{align*}
+y_0=& 1+\frac{1}{6}(x-1)^3+\frac{1}{180}(x-1)^6+...+\frac{1}{(2)(3)(5)(6)...(3n-1)(3n)}(x-1)^{3n}+... \\
+y_1=& (x-1)+\frac{1}{12}(x-1)^4+\frac{1}{504}(x-1)^7+...+\frac{1}{(3)(4)(6)(7)...(3n)(3n+1)}(x-1)^{3n+1}+...
+\end{align*}
+}
 
 \begin{exercise}
 Use power series methods to solve $y''+x^2y = 0$ at the point $x_0 = 0$.
 \end{exercise}
+\exsol{%
+The solution can be written as $y=a_0y_0+a_1y_1$, where
+\begin{align*}
+y_0=& 1+\frac{(-1)}{(3)(4)}x^4+\frac{(-1)^2}{(3)(4)(7)(8)}x^8+...+\frac{(-1)^n}{(3)(4)(7)(8)...(4n-1)(4n)}x^{4n}+... \\
+y_1=& x+\frac{(-1)}{(4)(5)}x^5+\frac{(-1)^2}{(4)(5)(8)(9)}x^9+...+\frac{(-1)^n}{(4)(5)(8)(9)...(4n)(4n+1)}x^{4n+1}+...
+\end{align*}
+}
 
-\begin{exercise}
-The methods work for other orders than second order.  Try the methods
-of this section to solve the first order system $y'-xy = 0$ at
-the point $x_0 = 0$.
-\end{exercise}
-
-\begin{exercise}[\myindex{Chebyshev's equation of order $p$}]
-\leavevmode
-\begin{tasks}
-\task Solve $(1-x^2)y''-xy' + p^2y = 0$ using power series methods at $x_0=0$.
-\task For what $p$ is there a polynomial solution?
-\end{tasks}
-\end{exercise}
-
-\begin{exercise}
-Find a polynomial solution to $(x^2+1) y''-2xy'+2y = 0$ using
-power series methods.
-\end{exercise}
-
-\begin{exercise}
-\leavevmode
-\begin{tasks}
-\task Use power series methods to solve $(1-x)y''+y = 0$ at the point $x_0 = 0$.
-\task Use the solution to part a) to find a solution
-for $xy''+y=0$ around the point $x_0=1$.
-\end{tasks}
-\end{exercise}
-
-\setcounter{exercise}{100}
 
 \begin{exercise}
 Use power series methods to solve $y'' + 2 x^3 y = 0$ at the point $x_0 =
@@ -1114,7 +1202,125 @@ $y(x) = a_0 + a_1 x -\frac{a_0}{10} x^5 - \frac{a_1}{15} x^6
 \cdots$
 }
 
+
+\begin{exercise}
+The methods work for other orders than second order.  Try the methods
+of this section to solve the first order system $y'-xy = 0$ at
+the point $x_0 = 0$.
+\end{exercise}
+\exsolution{%
+Letting $y=\sum_{k=0}^\infty a_kx^k$, differentiating (and re-indexing) and plugging into the ODE we get
+\begin{align*}
+\sum_{k=0}^\infty(k+1)a_{k+1}x^k-\sum_{k=0}^\infty a_kx^{k+1}=&0 \\
+a_1+\sum_{k=1}^\infty(k+1)a_{k+1}x^k-\sum_{k=1}^\infty a_{k-1}x^{k}=&0 \\
+\end{align*}
+This gives $a_1=0$ and 
+\begin{align*}
+a_{k+1}=\frac{a_{k-1}}{k+1}
+\end{align*}
+Giving
+\begin{align*}
+&a_2=\frac{a_0}{2},\quad a_3=0,\quad a_4=\frac{a_0}{(2)(4)},\quad a_5=0\quad ... \\
+&a_{2n}=\frac{a_0}{\underbrace{(2)(4)(6)...(2n)}_{(2n)!!}},\quad a_{2n+1}=0
+\end{align*}
+So the solution is 
+\begin{align*}
+y=a_0\sum_{n=0}^\infty \frac{x^n}{(2n)!!}=a_0e^{x^2/2}
+\end{align*}
+}
+
 \pagebreak[2]
+\begin{exercise}[\myindex{Chebyshev's equation of order $p$}]
+\leavevmode
+\begin{tasks}
+\task Solve $(1-x^2)y''-xy' + p^2y = 0$ using power series methods at $x_0=0$.
+\task For what $p$ is there a polynomial solution?
+\end{tasks}
+\end{exercise}
+\exsolution{%
+(a) Setting $y=\sum_{k=0}^\infty a_k x^k$ and plugging into the ODE
+\begin{align*}
+&\sum_{k=2}^\infty k(k-1)a_kx^{k-2}-\sum_{k=2}^\infty k(k-1)a_kx^k-\sum_{k=1}^\infty ka_kx^k+\sum_{k=0}^\infty p^2a_kx^k=0 \\
+& 2a_2+6a_3x-a_1x+p^2a_0+p^2a_1x+\sum_{k=2}^\infty \left[ (k+2)(k+1)a_{k+2}-k(k-1)a_k-ka_k+p^2a_k\right]x^k=0
+\end{align*}
+This gives $a_2=-p^2a_0/2$, $a_3=(1-p^2)a_1/6$ and the relation
+\begin{align*}
+a_{k+2}=\frac{k^2-p^2}{(k+2)(k+1)}a_k
+\end{align*}
+Giving
+\begin{align*}
+& a_4=\frac{(2-p^2)(0^2-p^2)}{4!}a_0,\quad a_5=\frac{(3^2-p^2)(1^2-p^2)}{5!}a_1 \\
+& a_6=\frac{(4^2-p^2)(2^2-p^2)(0^2-p^2)}{6!}a_0,\quad a_7=\frac{(5^2-p^2)(3^2-p^2)(1^2-p^2)}{7!}a_1\quad ...
+\end{align*}
+So for even $k$
+\begin{align*}
+a_{2n}=\frac{\left( (2n-2)^2-p^2\right)\left( (2n-4)^2-p^2\right)...\left( 0^2-p^2\right)}{(2n)!}a_0
+\end{align*}
+And for odd $k$
+\begin{align*}
+a_{2n+1}=\frac{\left( (2n-1)^2-p^2\right)\left( (2n-3)^2-p^2\right)...\left( 1^2-p^2\right)}{(2n+1)!}a_1
+\end{align*}
+So the solution can be written as $y=a_0y_0+a_1y_1$, where
+\begin{align*}
+y_0 =& 1+\frac{(0^2-p^2)}{2}x^2+\frac{(2^2-p^2)(0^2-p^2)}{4!}x^4+...+\frac{\left( (2n-2)^2-p^2\right)\left( (2n-4)^2-p^2\right)...\left( 0^2-p^2\right)}{(2n)!}x^{2n}+... \\
+y_1=& x+\frac{(1^2-p^2)}{3!}x^3+\frac{(3^2-p^2)(1^2-p^2)}{5!}x^5+...+\frac{\left( (2n-1)^2-p^2\right)\left( (2n-3)^2-p^2\right)...\left( 1^2-p^2\right)}{(2n+1)!}x^{2n+1}+...
+\end{align*}
+\\
+(b)
+If $p$ is an even integer, the series for $y_0$ terminates, whereas if $p$ is an odd integer the series for $y_1$ terminates. Both cases giving a polynomial solution.
+}
+
+\begin{exercise}
+Find a polynomial solution to $(x^2+1) y''-2xy'+2y = 0$ using
+power series methods.
+\end{exercise}
+\exsol{%
+$y=a_0+a_1x-a_0x^2=a_0(1-x^2)+a_1x$
+}
+
+\begin{exercise}
+\leavevmode
+\begin{tasks}
+\task Use power series methods to solve $(1-x)y''+y = 0$ at the point $x_0 = 0$.
+\task Use the solution to part a) to find a solution
+for $xy''+y=0$ around the point $x_0=1$.
+\end{tasks}
+\end{exercise}
+\exsolution{%
+(a) Plugging the series solution into the ODE
+\begin{align*}
+&\sum_{k=2}^\infty a_k(k-1)kx^{k-2}-\sum_{k=2}^\infty a_k(k-1)kx^{k-1}+\sum_{k=0}^\infty a_kx^k=0 \\
+& \sum_{k=0}^\infty a_{k+2}(k+1)(k+2)x^{k}-\sum_{k=1}^\infty a_{k+1}(k+1)kx^{k}+\sum_{k=0}^\infty a_kx^k=0  \\
+& 2a_2+a_0 +\sum_{k=1}^\infty \left[ a_{k+2}(k+1)(k+2)-a_{k+1}k(k+1)+a_k\right] x^k=0
+\end{align*}
+This gives $a_2=-a_0/2$ and the relation
+\begin{align*}
+a_{k+2}=\frac{a_{k+1}k(k+1)-a_k}{(k+1)(k+2)}
+\end{align*}
+Giving
+\begin{align*}
+a_3=-\frac{a_0+a_1}{(2)(3)},\quad a_4=-\frac{a_0/2+a_1}{(3)(4)},\quad  a_5=-\frac{a_0/3+\frac{5a_1}{(2)(3)}}{(4)(5)}\quad ...
+\end{align*}
+The solution is then 
+\begin{align*}
+y=&\sum_{k=0}^\infty a_kx^k= a_0+a_1x-\frac{a_0}{2	}x^2-\frac{a_0+a_1}{(2)(3)}x^3-\frac{a_0/2+a_1}{(3)(4)}x^4+... \\
+y=& a_0\left[ 1-\frac{x^2}{2}-\frac{x^3}{6}-\frac{x^4}{24}-\frac{x^5}{60}+...\right] + a_1\left[x-\frac{x^3}{6}-\frac{x^4}{12}-\frac{x^5}{24}+...\right]
+\end{align*}
+\\
+(b)
+Let $x=z-1$, then the equation becomes
+\begin{align*}
+(z-1)\frac{d^2y}{dz^2}+y=0
+\end{align*}
+At $x=1\rightarrow z=0$, so we're solving this equation near $z=0$ which is the same as part (a), therefore the solution is 
+\begin{align*}
+y=& a_0\left[ 1-\frac{z^2}{2}-\frac{z^3}{6}-\frac{z^4}{24}-\frac{z^5}{60}+...\right] + a_1\left[z-\frac{z^3}{6}-\frac{z^4}{12}-\frac{z^5}{24}+...\right] \\
+y=& a_0\left[ 1-\frac{(x+1)^2}{2}-\frac{(x+1)^3}{6}-\frac{(x+1)^4}{24}-\frac{(x+1)^5}{60}+...\right] + \\
+& a_1\left[(x+1)-\frac{(x+1)^3}{6}-\frac{(x+1)^4}{12}-\frac{(x+1)^5}{24}+...\right] 
+\end{align*}
+}
+
+
 \begin{exercise}[challenging]
 Power series methods also work for nonhomogeneous equations.
 \begin{tasks}

--- a/ch-power-ser.tex
+++ b/ch-power-ser.tex
@@ -287,6 +287,12 @@ cover many of the series that arise in practice.  Often if the root test
 applies, so does the ratio test, and vice versa, though the limit might
 be easier to compute in one way than the other.
 
+\begin{example}
+	\emph{Geogebra Activity:} Explore Radius of Convergence with \href{https://www.geogebra.org/m/sxncc9xd}{this Geogebra applet}. Write down a few different series and see if you can deduce the radius of convergence by observing for what range of values $t$ is the sum converging towards a single value (the red dots). 
+	\end{example}
+
+
+
 \subsection{Analytic functions}
 
 Functions represented by power series are called
@@ -506,6 +512,15 @@ x + \sum_{k=0}^\infty {(-1)}^k x^k - \sum_{k=0}^\infty x^k
 =
 - x + \sum_{\substack{k=3 \\ k \text{ odd}}}^\infty (-2) x^k .
 \end{equation*}
+
+
+\begin{example}
+	\emph{Geogebra Activity:} Use \href{https://www.geogebra.org/m/zshaps3d}{this Geogebra applet} to explore how the truncated Taylor series approximates different functions. Note how the approximations improves as you increase $N$, and how the region of best approximation changes as you change $x_0$. Try some rational functions and see how the series approximation is only valid for a certain range of $x$ no matter how large $N$ gets.
+\end{example}
+
+
+
+\subsection{Analytic functions}
 
 \subsection{Exercises}
 
@@ -1054,8 +1069,8 @@ a_5 = \frac{2(3-n)}{(5)(4)} a_3 = \frac{2^2(3-n)(1-n)}{(5)(4)(3)(2)} a_1 ,
 Let us separate the even and odd coefficients.
 We find that 
 \begin{align*}
-a_{2m} &=\frac{2^m(-n)(2-n)\cdots(2m-2-n)}{(2m)!} , \\
-a_{2m+1} &=\frac{2^m(1-n)(3-n)\cdots(2m-1-n)}{(2m+1)!} .
+a_{2m} &=\frac{2^m(-n)(2-n)\cdots(2m-2-n)}{(2m)!}a_0 , \\
+a_{2m+1} &=\frac{2^m(1-n)(3-n)\cdots(2m-1-n)}{(2m+1)!}a_1 .
 \end{align*}
 
 Let us write down the two series, one with the even powers and one with the
@@ -1137,14 +1152,15 @@ y_1=& x+\frac{(-4)}{(3)(4)}x^4+\frac{(-4)^2}{(3)(4)(6)(7)}x^7+...+\frac{(-4)^n}{
 }
 
 \begin{exercise}
-Use power series methods to solve $y''-xy = 0$ at the point $x_0 = 1$.
+Use power series methods to solve $y''-xy = 0$ at the point $x_0 = 1$. You may compute only terms up to 4th order. 
 \end{exercise}
 \exsol{%
-Note: See Example 1.2.2. 
+Note: In contrast to Example 4.2.2, we need to expand in powers of $(x-1)^n$. 
+
 The solution can be written as $y=a_0y_0+a_1y_1$, where
 \begin{align*}
-y_0=& 1+\frac{1}{6}(x-1)^3+\frac{1}{180}(x-1)^6+...+\frac{1}{(2)(3)(5)(6)...(3n-1)(3n)}(x-1)^{3n}+... \\
-y_1=& (x-1)+\frac{1}{12}(x-1)^4+\frac{1}{504}(x-1)^7+...+\frac{1}{(3)(4)(6)(7)...(3n)(3n+1)}(x-1)^{3n+1}+...
+y_0=& 1+\frac{1}{2}(x-1)^2+\frac{1}{6}(x-1)^3+...+\frac{1}{24}(x-1)^4+... \\
+y_1=& (x-1)+\frac{1}{6}(x-1)^3+\frac{1}{12}(x-1)^4+...
 \end{align*}
 }
 

--- a/ch-systems.tex
+++ b/ch-systems.tex
@@ -4509,7 +4509,7 @@ e^{2t}
 This machinery can also be generalized to higher multiplicities
 and higher defects.
 We will not go over this method in detail, but let us just sketch the ideas.  Suppose that $A$
-has an eigenvalue $\lambda$ of multiplicity $m$.
+has an eigenvalue $\lambda$ of multiplicity $k$.
 We find vectors such that
 \begin{equation*}
 {(A - \lambda I)}^k \vec{v} = \vec{0},

--- a/convert-to-mbx.pl
+++ b/convert-to-mbx.pl
@@ -1296,6 +1296,7 @@ while(1)
 				print $out "  <caption>$caption</caption>\n";
 
 				if ($fig =~ m/^[ \n]*\\diffyincludegraphics\{[^}]*?\}\{([^}]*?)\}\{([^}]*?)\}[ \n]*$/) {
+					print "\n\n\nTHISONE\n\nFIG=>$fig<\n\n";		
 					my $thesize = $1;
 					my $thefile = "figures/$2";
 					$thesize =~ s/width=//g;

--- a/convert-to-mbx.pl
+++ b/convert-to-mbx.pl
@@ -1511,7 +1511,52 @@ while(1)
 		close_paragraph();
 		print $out "</statement>\n</exercise>\n";
 
-	} elsif ($para =~ s/^\\begin\{center\}[ \n]*//) {
+	} 
+	
+	#BEGIN MODIFCATIONS
+	elsif ($para =~ s/^\\begin\{video\}[ \n]*//) {
+		
+		print "TREFORTESTBEGIN\n";
+
+
+close_paragraph();
+		$youtubeid = "";
+		my $title = "";
+		my $vidid="";
+
+		$example_num = $example_num+1;
+		my $the_num = get_example_number ();
+
+		
+		if ($para =~ s/^\[(.*?)\]\[(.*?)\]\[(.*?)\][ \n]*//s) {
+			$youtubeid = do_thmtitle_subs($1);
+			$title=$2;
+			$vidid=$3;
+			print $out "<project xml:id=\"$vidid\" number=\"$the_num\">\n";
+			print $out "<title>$title</title>\n";
+		}
+		open_paragraph();
+		
+
+	}elsif ($para =~ s/^\\end\{video\}[ \n]*//) {
+	close_paragraph();	
+	print $out "<video youtube=\"$youtubeid\">";
+		print $out "</video>\n";
+		print $out "</project>\n";
+		
+
+	} 
+
+
+
+
+	#END MODIFCATIONS
+	
+	
+	
+	
+	
+	elsif ($para =~ s/^\\begin\{center\}[ \n]*//) {
 		#FIXME: no centering yet
 		open_paragraph();
 		print "(begin center)";

--- a/convert-to-mbx.sh
+++ b/convert-to-mbx.sh
@@ -53,8 +53,11 @@ while [ "$1" != "" ]; do
         --kill-generated)
 	    echo "OPTION (kill-generated) Killing generated figures and exiting."
 	    cd figures
-	    rm *-mbx.(svg|png)
-	    rm *-tex4ht.(svg|png)
+	    rm *-mbx.svg
+		 rm *-mbx.png
+	    rm *-tex4ht.svg
+		 rm *-tex4ht.pngcd
+		 
 	    cd ..
 	    exit
 	    ;;

--- a/convert-to-mbx.sh
+++ b/convert-to-mbx.sh
@@ -108,7 +108,7 @@ if [ "$OPTSVG" = "yes" ] ; then
 	echo
 
 	cd figures
-	./optimize-svgs.sh
+	sh optimize-svgs.sh
 	cd ..
 fi
 

--- a/diffyqs-html.xsl
+++ b/diffyqs-html.xsl
@@ -11,7 +11,7 @@
 
   <!-- apply-imports applies also the original, apply-templates ignores the original-->
   <!-- need hardcoded numbers on everything, so nonstandard pretext -->
-  <xsl:template match="men|mrow|exercise|example|remark|theorem|lemma|proposition|corollary|principle|axiom|definition|chapter|appendix|section|subsection|subsubsection|figure" mode="number">
+  <xsl:template match="men|mrow|exercise|example|remark|theorem|lemma|proposition|corollary|principle|axiom|problem|definition|chapter|appendix|section|subsection|subsubsection|figure" mode="number">
     <xsl:choose>
       <xsl:when test="@number">
         <xsl:value-of select="@number"/>

--- a/diffyqs-html.xsl
+++ b/diffyqs-html.xsl
@@ -4,7 +4,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
   <!-- Import the usual html conversion templates            -->
-  <xsl:import href="/home/jirka/mathbook/xsl/pretext-html.xsl"/>
+ <xsl:import href="/home/tbazett/mathbook/xsl/pretext-html.xsl"/>
 
   <!-- Intend output for rendering by html -->
   <!--<xsl:output method="html" />-->

--- a/diffyqs-html.xsl
+++ b/diffyqs-html.xsl
@@ -11,7 +11,7 @@
 
   <!-- apply-imports applies also the original, apply-templates ignores the original-->
   <!-- need hardcoded numbers on everything, so nonstandard pretext -->
-  <xsl:template match="men|mrow|exercise|example|remark|theorem|lemma|proposition|corollary|principle|axiom|problem|definition|chapter|appendix|section|subsection|subsubsection|figure" mode="number">
+  <xsl:template match="men|mrow|exercise|example|remark|theorem|lemma|table|project|proposition|corollary|principle|axiom|problem|definition|chapter|appendix|section|subsection|subsubsection|figure" mode="number">
     <xsl:choose>
       <xsl:when test="@number">
         <xsl:value-of select="@number"/>

--- a/diffyqs-publisher.xml
+++ b/diffyqs-publisher.xml
@@ -20,6 +20,9 @@
 	<knowl list="no" />
 	<knowl remark="no" />
 	<knowl figure="no" />
+	<knowl problem="no" />
+	<knowl project="yes" />
+	<knowl Video="yes" />
 	<knowl table="no" />
 	<knowl listing="no" />
 	<knowl exercise-inline="no" />

--- a/diffyqs-publisher.xml
+++ b/diffyqs-publisher.xml
@@ -12,6 +12,8 @@
         <!-- Google search, via masthead textbox is switched on    -->
         <!-- and associated with a Google account via CX number    -->
         <search google-cx="006490116505509195242:1mxn4dbgh8e"/>
+		<analytics google-gst="G-GZD2XYF7R9"/>
+		<video privacy="no"/>
 	
 	<knowl theorem="no" />
 	<knowl proof="yes" />

--- a/diffyqs.tex
+++ b/diffyqs.tex
@@ -26,7 +26,7 @@
 % This is useful for debugging
 %\overfullrule=2cm
 
-\author{Originally by Ji\v{r}\'i Lebl and adapted for UVic by Trefor Bazett}
+\author{Adapted for Math 204 at the University of Victoria}
 
 \title{Notes on Diffy Qs: Introduction to Differential Equations}
 
@@ -68,17 +68,10 @@
 %mbx <frontmatter>
 %mbx   <titlepage>
 %mbx     <author>
-%mbx       <personname>Jiří Lebl</personname>
-%mbx       <department>Department of Mathematics</department>
-%mbx       <institution>Oklahoma State University</institution>
-%mbx       <email>jiri.lebl@gmail.com</email>
+%mbx       <personname>Adapted for Math 204 at the University of Victoria</personname>
+
 %mbx     </author>
-%mbx     <author>
-%mbx       <personname>Trefor Bazett</personname>
-%mbx       <department>Department of Mathematics &amp; Statistics </department>
-%mbx       <institution>University of Victoria</institution>
-%mbx       <email>tbazett@uvic.ca</email>
-%mbx     </author>
+
 
 
    
@@ -346,7 +339,7 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 
 
 % Nonlinear systems chapter
-\input ch-nonlin-systems.tex
+%\input ch-nonlin-systems.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \appendix

--- a/diffyqs.tex
+++ b/diffyqs.tex
@@ -26,7 +26,7 @@
 % This is useful for debugging
 %\overfullrule=2cm
 
-\author{Ji\v{r}\'i Lebl, Adapted for UVic by Trefor Bazett}
+\author{Originally by Ji\v{r}\'i Lebl and adapted for UVic by Trefor Bazett}
 
 \title{Notes on Diffy Qs: Differential Equations for Engineers}
 
@@ -75,19 +75,34 @@
 %mbx       <institution>Oklahoma State University</institution>
 %mbx       <email>jiri.lebl@gmail.com</email>
 %mbx     </author>
+
+%mbx     <author>
+%mbx       <personname>Trefor Bazett</personname>
+%mbx       <department>Department of Mathematics &amp; Statistics </department>
+%mbx       <institution>University of Victoria</institution>
+%mbx       <email>tbazett@uvic.ca</email>
+%mbx     </author>
 %mbx
 %mbx     <date><today /></date>
+
+   
+
 %mbx
 %mbx   </titlepage>
 %mbx
 %mbx   <colophon>
+%mbx     <p>
+%mbx        This book was originally authored by Jiří Lebl. This version of the textbook was forked by Trefor Bazett and adapted for use at the University of Victoria. Currently the vast majority of the book is the content from Jiří Lebl; for a more precise comparison please consult the respective github repositories for the original and the forked version of this text. 
+%mbx     </p>
+%mbx    
+%mbx    
 %mbx
 %mbx     <copyright>
 %mbx       <year>2008<ndash />2021</year>
 %mbx       <holder>Jiří Lebl</holder>
 %mbx       <minilicense>Creative Commons Attribution-Non-commercial-Share Alike 4.0 International License and the Creative Commons Attribution-Share Alike 4.0 International License</minilicense>
 %mbx       <shortlicense>
-%mbx         This work is dual licensed under the Creative Commons Attribution-Non-commercial-Share Alike 4.0 International License and
+%mbx        This work is dual licensed under the Creative Commons Attribution-Non-commercial-Share Alike 4.0 International License and
 %mbx         the Creative Commons Attribution-Share Alike 4.0 International License.  To view a copy of these licenses, visit
 %mbx         <url href="https://creativecommons.org/licenses/by-nc-sa/4.0/">https://creativecommons.org/licenses/by-nc-sa/4.0/</url> or
 %mbx         <url href="https://creativecommons.org/licenses/by-sa/4.0/">https://creativecommons.org/licenses/by-sa/4.0/</url>
@@ -120,8 +135,9 @@
 %mbx       See <url href="https://www.jirka.org/diffyqs/">https://www.jirka.org/diffyqs/</url>
 %mbx       for more information
 %mbx       (including contact information).
-%mbx       The LaTeX source for the book is available for possible modification and customization
-%mbx       at github: <url href="https://github.com/jirilebl/diffyqs">https://github.com/jirilebl/diffyqs</url>
+%mbx       The LaTeX source for the original book by Jiří Lebl is available for possible modification and customization
+%mbx       at github: <url href="https://github.com/jirilebl/diffyqs">https://github.com/jirilebl/diffyqs</url>. The LaTeX source for the forked version of the book adapted by Trefor Bazett is available for possible modification and customization
+%mbx       at github: <url href="https://github.com/tbazett/diffyqs">https://github.com/tbazett/diffyqs</url>
 %mbx     </p>
 %mbx
 %mbx   </colophon>
@@ -144,7 +160,7 @@ Typeset in \LaTeX.
 \bigskip
 
 \noindent
-Copyright \copyright 2008--2021 Ji\v{r}\'i Lebl
+Copyright \copyright 2008--2021 Ji\v{r}\'i Lebl 
 
 %PRINT
 % not for lulu
@@ -266,12 +282,12 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Higher order linear ODEs chapter
-\input ch-higher-order-ode.tex
+%\input ch-higher-order-ode.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Systems of ODEs chapter
-\input ch-systems.tex
+\%input ch-systems.tex
 
 %mbxSTARTIGNORE
 %This makes contents fit if needed
@@ -283,27 +299,27 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Fourier series and PDEs chapter
-\input ch-fourier-and-pde.tex
+%\input ch-fourier-and-pde.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Eigenvalue problems chapter
-\input ch-eigenvalue-probs.tex
+%\input ch-eigenvalue-probs.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % The Laplace transform chapter
-\input ch-laplace.tex
+%\input ch-laplace.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Power series methods chapter
-\input ch-power-ser.tex
+%\input ch-power-ser.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Nonlinear systems chapter
-\input ch-nonlin-systems.tex
+%\input ch-nonlin-systems.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \appendix
@@ -316,12 +332,12 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Linear algebra appendix
-\input ap-linear-algebra.tex
+%\input ap-linear-algebra.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Nonlinear systems chapter
-\input ap-laplace-list.tex
+%\input ap-laplace-list.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/diffyqs.tex
+++ b/diffyqs.tex
@@ -35,21 +35,20 @@
 
 %mbx <!--BEFORE book-->
 
-%mbxdocinfo    <website>
-%mbxdocinfo        <title>www.jirka.org/diffyqs/</title>
-%mbxdocinfo        <url>https://www.jirka.org/diffyqs/</url>
-%mbxdocinfo    </website>
+
 %mbxdocinfo
-%mbxdocinfo    <brandlogo source="logo.png" url="https://www.jirka.org/diffyqs/" />
+%mbxdocinfo    <brandlogo source="logo.png"  />
 %mbxdocinfo
 %mbxdocinfo    <rename element="inlineexercise">Exercise</rename>
+%mbxdocinfo    <rename element="project">Video</rename>
 %mbxdocinfo    <rename element="divisionalexercise">Exercise</rename>
 %mbxdocinfo
 %mbxdocinfo    <latex-preamble>
 %mbxdocinfo        <package>cancel</package>
 %mbxdocinfo    </latex-preamble>
-%mbxdocinfo
+%mbxdocinfo   
 %mbxdocinfo    <initialism>DIFFYQS</initialism>
+%mbxdocinfo
 
 
 %mbxmacro \newcommand{\nicefrac}[2]{{{}^{#1}}\!/\!{{}_{#2}}}
@@ -60,6 +59,7 @@
 %mbxmacro \newcommand{\mybxbg}[1]{\boxed{#1}}
 %mbxmacro \newcommand{\mybxsm}[1]{\boxed{#1}}
 %mbxmacro \newcommand{\allowbreak}{}
+
 
 \begin{document}
 
@@ -271,13 +271,16 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%\input test.tex
+
+
 % Introduction chapter
 \input ch-intro.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % First order ODEs chapter
-\input ch-first-order-ode.tex
+%\input ch-first-order-ode.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -287,7 +290,7 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Systems of ODEs chapter
-\%input ch-systems.tex
+%input ch-systems.tex
 
 %mbxSTARTIGNORE
 %This makes contents fit if needed

--- a/diffyqs.tex
+++ b/diffyqs.tex
@@ -26,7 +26,7 @@
 % This is useful for debugging
 %\overfullrule=2cm
 
-\author{Ji\v{r}\'i Lebl}
+\author{Ji\v{r}\'i Lebl, Adapted for UVic by Trefor Bazett}
 
 \title{Notes on Diffy Qs: Differential Equations for Engineers}
 

--- a/diffyqs.tex
+++ b/diffyqs.tex
@@ -28,7 +28,7 @@
 
 \author{Originally by Ji\v{r}\'i Lebl and adapted for UVic by Trefor Bazett}
 
-\title{Notes on Diffy Qs: Differential Equations for Engineers}
+\title{Notes on Diffy Qs: Introduction to Differential Equations}
 
 % Set up our index
 \makeindex
@@ -47,7 +47,7 @@
 %mbxdocinfo        <package>cancel</package>
 %mbxdocinfo    </latex-preamble>
 %mbxdocinfo   
-%mbxdocinfo    <initialism>DIFFYQS</initialism>
+%mbxdocinfo    <initialism>ODEs:</initialism>
 %mbxdocinfo
 
 
@@ -63,27 +63,23 @@
 
 \begin{document}
 
-%mbx <title>Notes on Diffy Qs</title>
-%mbx <subtitle>Differential Equations for Engineers</subtitle>
+%mbx <title>Introduction to Differential Equations</title>
 %mbx
 %mbx <frontmatter>
 %mbx   <titlepage>
-%mbx
 %mbx     <author>
 %mbx       <personname>Jiří Lebl</personname>
 %mbx       <department>Department of Mathematics</department>
 %mbx       <institution>Oklahoma State University</institution>
 %mbx       <email>jiri.lebl@gmail.com</email>
 %mbx     </author>
-
 %mbx     <author>
 %mbx       <personname>Trefor Bazett</personname>
 %mbx       <department>Department of Mathematics &amp; Statistics </department>
 %mbx       <institution>University of Victoria</institution>
 %mbx       <email>tbazett@uvic.ca</email>
 %mbx     </author>
-%mbx
-%mbx     <date><today /></date>
+
 
    
 
@@ -122,8 +118,8 @@
 %mbx     </p>
 %mbx     <p>
 %mbx       During the writing of this book, 
-%mbx       the author was in part supported by NSF grant DMS-0900885 and
-%mbx       DMS-1362337.
+%mbx       Lebl was in part supported by NSF grant DMS-0900885 and
+%mbx       DMS-1362337 while Bazett was in part supported by an LTSI OER grant at the University of Victoria. 
 %mbx     </p>
 %mbx     <p>
 %mbx       The date is the main identifier of version.  The major version / edition
@@ -141,6 +137,18 @@
 %mbx     </p>
 %mbx
 %mbx   </colophon>
+%mbx <abstract>
+%mbx     <p>
+%mbx     This book consists of an introduction to Differential Equations, primarily focusing on Ordinary Differential Equations (ODEs). It is used specifically in Math 204 at the University of Victoria, but covers a fairly typical one-semester introductory course for students who have taken Calculus.
+%mbx     </p>
+%mbx     <p>
+%mbx     This book is free and open source, which means that anyone can modify the source code for this book, please see the Colophon for more information. Specicfically, this version of the book, maintained by Trefor Bazett at the University of Victoria, has been forked from <url href="https://www.jirka.org/diffyqs/">the original text by Jiří Lebl.</url>
+%mbx     </p>
+%mbx     <p>
+%mbx     What are differential equations? Check out the first video from the book for an overview!
+%mbx    <video youtube="KM3n22ZE8Bw"></video>
+%mbx     </p>
+%mbx </abstract>
 %mbx </frontmatter>
 
 %mbxSTARTIGNORE
@@ -280,17 +288,35 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % First order ODEs chapter
-%\input ch-first-order-ode.tex
+\input ch-first-order-ode.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Higher order linear ODEs chapter
-%\input ch-higher-order-ode.tex
+\input ch-higher-order-ode.tex
+
+% The Laplace transform chapter
+\input ch-laplace.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% Power series methods chapter
+\input ch-power-ser.tex
+
+% Fourier series and PDEs chapter
+\input ch-fourier-and-pde.tex
+
+
+% Eigenvalue problems chapter
+\input ch-eigenvalue-probs.tex
+
 % Systems of ODEs chapter
-%input ch-systems.tex
+\input ch-systems.tex
+
+
+
+
+
 
 %mbxSTARTIGNORE
 %This makes contents fit if needed
@@ -301,28 +327,26 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Fourier series and PDEs chapter
-%\input ch-fourier-and-pde.tex
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Eigenvalue problems chapter
-%\input ch-eigenvalue-probs.tex
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% The Laplace transform chapter
-%\input ch-laplace.tex
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Power series methods chapter
-%\input ch-power-ser.tex
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
 
 % Nonlinear systems chapter
-%\input ch-nonlin-systems.tex
+\input ch-nonlin-systems.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \appendix
@@ -335,12 +359,12 @@ at github: \url{https://github.com/jirilebl/diffyqs}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Linear algebra appendix
-%\input ap-linear-algebra.tex
+\input ap-linear-algebra.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Nonlinear systems chapter
-%\input ap-laplace-list.tex
+\input ap-laplace-list.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/fixup-html-file.pl
+++ b/fixup-html-file.pl
@@ -15,14 +15,14 @@ while($line = <STDIN>)
 	if ($line =~ m/<a class="index-button.*index-1.html.*Index/) {
 		# Add extra buttons
 
-		print "<a onclick=\"gtag('event','download',{'event_category': 'diffyqs', 'event_action': 'Link', 'event_label': 'PTXhtml(top) home diffyqs'});\"\n";
-		print " class=\"index-button toolbar-item button\" href=\"https://www.jirka.org/diffyqs/\" title=\"Home\" alt=\"Book Home\">Home</a>\n";
+		#print "<a onclick=\"gtag('event','download',{'event_category': 'diffyqs', 'event_action': 'Link', 'event_label': 'PTXhtml(top) home diffyqs'});\"\n";
+		#print " class=\"index-button toolbar-item button\" href=\"https://www.jirka.org/diffyqs/\" title=\"Web version of Original\" alt=\"Book Home\">Home</a>\n";
 
-		print "<a onclick=\"gtag('event','download',{'event_category': 'PDF', 'event_action': 'Download', 'event_label': 'PTXhtml(top) /diffyqs/diffyqs.pdf'});\"\n";
-		print " class=\"index-button toolbar-item button\" href=\"https://www.jirka.org/diffyqs/diffyqs.pdf\" title=\"PDF\">PDF</a>\n";
+		#print "<a onclick=\"gtag('event','download',{'event_category': 'PDF', 'event_action': 'Download', 'event_label': 'PTXhtml(top) /diffyqs/diffyqs.pdf'});\"\n";
+		#print " class=\"index-button toolbar-item button\" href=\"https://www.jirka.org/diffyqs/diffyqs.pdf\" title=\"PDF of Original\">PDF</a>\n";
 
-		print "<a onclick=\"gtag('event','download',{'event_category': 'amazon', 'event_action': 'Link', 'event_label': 'PTXhtml(top) diffyqs'});\"\n";
-		print " class=\"index-button toolbar-item button\" style=\"width:100px;\" href=\"https://smile.amazon.com/dp/1706230230\" title=\"Paperback\" alt=\"Buy Paperback\">Paperback</a>\n";
+		#print "<a onclick=\"gtag('event','download',{'event_category': 'amazon', 'event_action': 'Link', 'event_label': 'PTXhtml(top) diffyqs'});\"\n";
+		#print " class=\"index-button toolbar-item button\" style=\"width:100px;\" href=\"https://smile.amazon.com/dp/1706230230\" title=\"Paperback of Original\" alt=\"Buy Paperback\">Paperback</a>\n";
 	}
 	if ($line =~ m/<\/head>/) {
 		# Fast preview doesn't seem worth it and it could be confusing since it's not quite right so disable it


### PR DESCRIPTION
This is a relatively small commit, it merely alters a single letter that is probably a typo. It lies in the file `ch-systems.tex` line 4546, I think it should be `multiplicity $k$` instead of `multiplicity $m$` as this is conventional across more math textbooks, and also it is probably a typo as the following text after that statements involves using the variable k instead of m.